### PR TITLE
[Feat]: 참여 그룹, 찜한 그룹

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'org.springframework.boot' version '2.7.2'
 	id 'io.spring.dependency-management' version '1.0.12.RELEASE'
 	id 'java'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.gloddy'
@@ -22,6 +29,8 @@ dependencies {
 
 	//jpa
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 
 	//redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -57,4 +66,26 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+	main.java.srcDir querydslDir
+}
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }

--- a/src/main/java/com/gloddy/server/apply/entity/Apply.java
+++ b/src/main/java/com/gloddy/server/apply/entity/Apply.java
@@ -52,4 +52,8 @@ public class Apply extends BaseTimeEntity {
     public void updateStatus(Status status) {
         this.status = status;
     }
+
+    public boolean isApproved() {
+        return this.status.isApprove();
+    }
 }

--- a/src/main/java/com/gloddy/server/apply/entity/vo/Status.java
+++ b/src/main/java/com/gloddy/server/apply/entity/vo/Status.java
@@ -12,4 +12,8 @@ public enum Status {
     ;
 
     private final String status;
+
+    public boolean isApprove() {
+        return this == APPROVE;
+    }
 }

--- a/src/main/java/com/gloddy/server/apply/service/ApplyService.java
+++ b/src/main/java/com/gloddy/server/apply/service/ApplyService.java
@@ -7,9 +7,11 @@ import com.gloddy.server.apply.entity.vo.Status;
 import com.gloddy.server.apply.repository.ApplyJpaRepository;
 import com.gloddy.server.auth.entity.User;
 import com.gloddy.server.user.repository.UserRepository;
+import com.gloddy.server.core.utils.event.ApplyApproveEvent;
 import com.gloddy.server.group.entity.Group;
 import com.gloddy.server.group.repository.GroupJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +22,7 @@ public class ApplyService {
     private final ApplyJpaRepository applyJpaRepository;
     private final UserRepository userRepository;
     private final GroupJpaRepository groupJpaRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     // TODO: user exception 처리
     @Transactional
@@ -54,6 +57,10 @@ public class ApplyService {
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 지원서"));
         if(checkCaptain(groupId, userId)){
             apply.updateStatus(status);
+        }
+
+        if (apply.isApproved()) {
+            applicationEventPublisher.publishEvent(new ApplyApproveEvent(userId, groupId));
         }
     }
 

--- a/src/main/java/com/gloddy/server/auth/entity/User.java
+++ b/src/main/java/com/gloddy/server/auth/entity/User.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@Table(name = "user")
+@Table(name = "users")
 public class User extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/gloddy/server/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/gloddy/server/auth/security/config/SecurityConfig.java
@@ -21,9 +21,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final JwtTokenExtractor jwtTokenExtractor;
     private final JwtTokenValidator jwtTokenValidator;
     private final AuthenticationProvider authenticationProvider;
-    @Value("${JWT_SECRET}")
+    @Value("${jwt.secret}")
     private String key;
-    @Value("${JWT_HEADER}")
+    @Value("${jwt.header}")
     private String secretHeader;
 
     @Override

--- a/src/main/java/com/gloddy/server/config/QuerydslConfig.java
+++ b/src/main/java/com/gloddy/server/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.gloddy.server.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+@RequiredArgsConstructor
+@Configuration
+public class QuerydslConfig {
+
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/gloddy/server/core/utils/DateTimeUtils.java
+++ b/src/main/java/com/gloddy/server/core/utils/DateTimeUtils.java
@@ -1,0 +1,16 @@
+package com.gloddy.server.core.utils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class DateTimeUtils {
+
+    public static LocalTime StringToLocalTime(String timeString) {
+        return LocalTime.parse(timeString);
+    }
+
+    public static LocalDateTime concatDateAndTime(LocalDate date, LocalTime time) {
+        return LocalDateTime.of(date, time);
+    }
+}

--- a/src/main/java/com/gloddy/server/core/utils/event/ApplyApproveEvent.java
+++ b/src/main/java/com/gloddy/server/core/utils/event/ApplyApproveEvent.java
@@ -1,0 +1,13 @@
+package com.gloddy.server.core.utils.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ApplyApproveEvent {
+    private Long userId;
+    private Long groupId;
+}

--- a/src/main/java/com/gloddy/server/core/utils/event/ApplyEventHandler.java
+++ b/src/main/java/com/gloddy/server/core/utils/event/ApplyEventHandler.java
@@ -1,0 +1,19 @@
+package com.gloddy.server.core.utils.event;
+
+import com.gloddy.server.group.service.UserGroupSaveService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ApplyEventHandler {
+
+    private final UserGroupSaveService userGroupSaveService;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void applyApproveEventHandler(ApplyApproveEvent applyApproveEvent) {
+        userGroupSaveService.saveUserGroup(applyApproveEvent.getUserId(), applyApproveEvent.getGroupId());
+    }
+}

--- a/src/main/java/com/gloddy/server/estimate/api/EstimateApi.java
+++ b/src/main/java/com/gloddy/server/estimate/api/EstimateApi.java
@@ -32,7 +32,7 @@ public class EstimateApi {
     }
 
     @ApiOperation("팀원 평가 - 칭찬 + 최고의 짝꿍")
-    @PostMapping("/groups/{groupId]/estimate")
+    @PostMapping("/groups/{groupId}/estimate")
     public ResponseEntity<Void> estimateInGroup(@AuthenticationPrincipal Long userId,
                                                 @PathVariable("groupId") Long groupId,
                                                 @RequestBody EstimateRequest estimateRequest) {

--- a/src/main/java/com/gloddy/server/estimate/service/EstimateService.java
+++ b/src/main/java/com/gloddy/server/estimate/service/EstimateService.java
@@ -3,6 +3,7 @@ package com.gloddy.server.estimate.service;
 import com.gloddy.server.estimate.dto.EstimateRequest;
 import com.gloddy.server.estimate.service.mate.MateSaveService;
 import com.gloddy.server.estimate.service.praise.PraiseService;
+import com.gloddy.server.group.service.UserGroupUpdateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,10 +14,12 @@ public class EstimateService {
 
     private final PraiseService praiseService;
     private final MateSaveService mateSaveService;
+    private final UserGroupUpdateService userGroupUpdateService;
 
     @Transactional
     public void estimateInGroup(Long userId, Long groupId, EstimateRequest request) {
         praiseService.praiseInGroup(request.getPraiseDtos(), groupId);
         mateSaveService.save(request.getMateDto(), userId);
+        userGroupUpdateService.completePraise(userId, groupId);
     }
 }

--- a/src/main/java/com/gloddy/server/group/api/UserGroupApi.java
+++ b/src/main/java/com/gloddy/server/group/api/UserGroupApi.java
@@ -26,7 +26,7 @@ public class UserGroupApi {
 
     @ApiOperation("내가 참여했던 그룹 조회 - 나의 모임 아랫 부분 - paging처리 o")
     @GetMapping("/groups/my-participated")
-    public PageResponse<GroupResponse.GetGroup> getParticipatedMyGroup(
+    public PageResponse<GroupResponse.GetParticipatedGroup> getParticipatedMyGroup(
             @AuthenticationPrincipal Long userId,
             @RequestParam int page,
             @RequestParam int size) {

--- a/src/main/java/com/gloddy/server/group/api/UserGroupApi.java
+++ b/src/main/java/com/gloddy/server/group/api/UserGroupApi.java
@@ -1,14 +1,14 @@
 package com.gloddy.server.group.api;
 
+import com.gloddy.server.core.response.PageResponse;
 import com.gloddy.server.group.dto.GroupResponse;
 import com.gloddy.server.group.service.MyGroupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,7 +18,15 @@ public class UserGroupApi {
     private final MyGroupService myGroupService;
 
     @GetMapping("/groups/my-expected")
-    public List<GroupResponse.GetGroup> getExpectedMyGroup(@AuthenticationPrincipal Long userId) {
+    public GroupResponse.GetGroups getExpectedMyGroup(@AuthenticationPrincipal Long userId) {
         return myGroupService.getExpectedMyGroup(userId);
+    }
+
+    @GetMapping("/groups/my-participated")
+    public PageResponse<GroupResponse.GetGroup> getParticipatedMyGroup(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam int page,
+            @RequestParam int size) {
+        return myGroupService.getParticipatedMyGroup(userId, page, size);
     }
 }

--- a/src/main/java/com/gloddy/server/group/api/UserGroupApi.java
+++ b/src/main/java/com/gloddy/server/group/api/UserGroupApi.java
@@ -1,0 +1,24 @@
+package com.gloddy.server.group.api;
+
+import com.gloddy.server.group.dto.GroupResponse;
+import com.gloddy.server.group.service.MyGroupService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class UserGroupApi {
+
+    private final MyGroupService myGroupService;
+
+    @GetMapping("/groups/my-expected")
+    public List<GroupResponse.GetGroup> getExpectedMyGroup(@AuthenticationPrincipal Long userId) {
+        return myGroupService.getExpectedMyGroup(userId);
+    }
+}

--- a/src/main/java/com/gloddy/server/group/api/UserGroupApi.java
+++ b/src/main/java/com/gloddy/server/group/api/UserGroupApi.java
@@ -3,6 +3,7 @@ package com.gloddy.server.group.api;
 import com.gloddy.server.core.response.PageResponse;
 import com.gloddy.server.group.dto.GroupResponse;
 import com.gloddy.server.group.service.MyGroupService;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,11 +18,13 @@ public class UserGroupApi {
 
     private final MyGroupService myGroupService;
 
+    @ApiOperation("내가 참여할 그룹 조회 - 나의 모임 윗부분 - paging처리 x")
     @GetMapping("/groups/my-expected")
     public GroupResponse.GetGroups getExpectedMyGroup(@AuthenticationPrincipal Long userId) {
         return myGroupService.getExpectedMyGroup(userId);
     }
 
+    @ApiOperation("내가 참여했던 그룹 조회 - 나의 모임 아랫 부분 - paging처리 o")
     @GetMapping("/groups/my-participated")
     public PageResponse<GroupResponse.GetGroup> getParticipatedMyGroup(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/gloddy/server/group/dto/GroupResponse.java
+++ b/src/main/java/com/gloddy/server/group/dto/GroupResponse.java
@@ -2,6 +2,7 @@ package com.gloddy.server.group.dto;
 
 import com.gloddy.server.core.dto.UserInfoDto;
 import com.gloddy.server.group.entity.Group;
+import com.gloddy.server.group.entity.UserGroup;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -67,6 +68,34 @@ public class GroupResponse {
         private String place;
         private String place_latitude;
         private String place_longitude;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetParticipatedGroup {
+        private Long groupId;
+        private String imageUrl;
+        private String title;
+        private String content;
+        // List<String> memberProfiles;
+        private int memberCount;
+        private String place;
+        private LocalDate meetDate;
+        private boolean isPraised;
+
+        public static GetParticipatedGroup from(UserGroup userGroup) {
+            return new GetParticipatedGroup(
+                    userGroup.getGroup().getId(),
+                    userGroup.getGroup().getFileUrl(),
+                    userGroup.getGroup().getTitle(),
+                    userGroup.getGroup().getContent(),
+                    userGroup.getGroup().getMemberCount(),
+                    userGroup.getGroup().getPlace(),
+                    userGroup.getGroup().getMeetDate(),
+                    userGroup.isPraised()
+            );
+        }
     }
 
 }

--- a/src/main/java/com/gloddy/server/group/dto/GroupResponse.java
+++ b/src/main/java/com/gloddy/server/group/dto/GroupResponse.java
@@ -1,6 +1,7 @@
 package com.gloddy.server.group.dto;
 
 import com.gloddy.server.core.dto.UserInfoDto;
+import com.gloddy.server.group.entity.Group;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -35,6 +36,18 @@ public class GroupResponse {
         int memberCount;
         String place;
         LocalDate meetDate;
+
+        public static GetGroup from(Group group) {
+            return new GetGroup(
+                    group.getId(),
+                    group.getFileUrl(),
+                    group.getTitle(),
+                    group.getContent(),
+                    group.getMemberCount(),
+                    group.getPlace(),
+                    group.getMeetDate()
+            );
+        }
     }
 
     @Getter

--- a/src/main/java/com/gloddy/server/group/entity/Group.java
+++ b/src/main/java/com/gloddy/server/group/entity/Group.java
@@ -58,7 +58,7 @@ public class Group extends BaseTimeEntity {
     private int maxUser;
 
     @Embedded
-    private UserGroups userGroups;
+    private UserGroups userGroups = UserGroups.empty();
 
     @Builder
     public Group(User user, String fileUrl, String title, String content, LocalDateTime startTime, LocalDateTime endTime,
@@ -74,6 +74,10 @@ public class Group extends BaseTimeEntity {
         this.placeLongitude = placeLongitude;
         this.maxUser = maxUser;
         this.school = school;
+    }
+
+    public void addUserGroup(UserGroup userGroup) {
+        this.userGroups.addUserGroups(userGroup);
     }
 
     public LocalDate getMeetDate() {

--- a/src/main/java/com/gloddy/server/group/entity/Group.java
+++ b/src/main/java/com/gloddy/server/group/entity/Group.java
@@ -2,6 +2,7 @@ package com.gloddy.server.group.entity;
 
 import com.gloddy.server.auth.entity.User;
 import com.gloddy.server.core.entity.common.BaseTimeEntity;
+import com.gloddy.server.group.entity.embedded.UserGroups;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -56,6 +57,9 @@ public class Group extends BaseTimeEntity {
     @Column(name = "max_user")
     private int maxUser;
 
+    @Embedded
+    private UserGroups userGroups;
+
     @Builder
     public Group(User user, String fileUrl, String title, String content, LocalDateTime startTime, LocalDateTime endTime,
                  String place, String placeLatitude, String placeLongitude, int maxUser, String school) {
@@ -74,5 +78,9 @@ public class Group extends BaseTimeEntity {
 
     public LocalDate getMeetDate() {
         return this.getStartTime().toLocalDate();
+    }
+
+    public int getMemberCount() {
+        return this.userGroups.getSize();
     }
 }

--- a/src/main/java/com/gloddy/server/group/entity/Group.java
+++ b/src/main/java/com/gloddy/server/group/entity/Group.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -37,14 +38,11 @@ public class Group extends BaseTimeEntity {
     @Column(name = "content", columnDefinition = "longtext")
     private String content;
 
-    @Column(name = "meet_date")
-    private LocalDate meetDate;
-
     @Column(name = "start_time")
-    private String startTime;
+    private LocalDateTime startTime;
 
     @Column(name = "end_time")
-    private String endTime;
+    private LocalDateTime endTime;
 
     @Column(name = "place")
     private String place;
@@ -59,13 +57,12 @@ public class Group extends BaseTimeEntity {
     private int maxUser;
 
     @Builder
-    public Group(User user, String fileUrl, String title, String content, LocalDate meetDate, String startTime, String endTime,
+    public Group(User user, String fileUrl, String title, String content, LocalDateTime startTime, LocalDateTime endTime,
                  String place, String placeLatitude, String placeLongitude, int maxUser, String school) {
         this.user = user;
         this.fileUrl = fileUrl;
         this.title = title;
         this.content = content;
-        this.meetDate = meetDate;
         this.startTime = startTime;
         this.endTime = endTime;
         this.place = place;
@@ -73,5 +70,9 @@ public class Group extends BaseTimeEntity {
         this.placeLongitude = placeLongitude;
         this.maxUser = maxUser;
         this.school = school;
+    }
+
+    public LocalDate getMeetDate() {
+        return this.getStartTime().toLocalDate();
     }
 }

--- a/src/main/java/com/gloddy/server/group/entity/UserGroup.java
+++ b/src/main/java/com/gloddy/server/group/entity/UserGroup.java
@@ -1,0 +1,45 @@
+package com.gloddy.server.group.entity;
+
+import com.gloddy.server.auth.entity.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "user_group")
+public class UserGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+    //나중에 스케줄링으로 처리하면 너무 편할 듯
+    @Column(name = "is_end")
+    private boolean isEnd;
+
+    @Column(name = "is_praised")
+    private boolean isPraised;
+
+    public static UserGroup empty() {
+        return new UserGroup();
+    }
+
+    public void init(User user, Group group) {
+        this.user = user;
+        this.group = group;
+        this.isEnd = false;
+        this.isPraised = false;
+    }
+}

--- a/src/main/java/com/gloddy/server/group/entity/UserGroup.java
+++ b/src/main/java/com/gloddy/server/group/entity/UserGroup.java
@@ -3,6 +3,7 @@ package com.gloddy.server.group.entity;
 import com.gloddy.server.auth.entity.User;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
@@ -10,6 +11,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
+@Getter
 @Table(name = "user_group")
 public class UserGroup {
 
@@ -41,5 +43,9 @@ public class UserGroup {
         this.group = group;
         this.isEnd = false;
         this.isPraised = false;
+    }
+
+    public void completePraise() {
+        this.isPraised = true;
     }
 }

--- a/src/main/java/com/gloddy/server/group/entity/embedded/UserGroups.java
+++ b/src/main/java/com/gloddy/server/group/entity/embedded/UserGroups.java
@@ -18,6 +18,14 @@ public class UserGroups {
     @OneToMany(mappedBy = "group")
     public List<UserGroup> userGroups = new ArrayList<>();
 
+    public static UserGroups empty() {
+        return new UserGroups();
+    }
+
+    public void addUserGroups(UserGroup userGroup) {
+        this.userGroups.add(userGroup);
+    }
+
     public int getSize() {
         return this.userGroups.size();
     }

--- a/src/main/java/com/gloddy/server/group/entity/embedded/UserGroups.java
+++ b/src/main/java/com/gloddy/server/group/entity/embedded/UserGroups.java
@@ -1,0 +1,24 @@
+package com.gloddy.server.group.entity.embedded;
+
+import com.gloddy.server.group.entity.UserGroup;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Embeddable
+public class UserGroups {
+
+    @OneToMany(mappedBy = "group")
+    public List<UserGroup> userGroups = new ArrayList<>();
+
+    public int getSize() {
+        return this.userGroups.size();
+    }
+}

--- a/src/main/java/com/gloddy/server/group/repository/GroupJpaRepository.java
+++ b/src/main/java/com/gloddy/server/group/repository/GroupJpaRepository.java
@@ -1,6 +1,7 @@
 package com.gloddy.server.group.repository;
 
 import com.gloddy.server.group.entity.Group;
+import com.gloddy.server.group.repository.custom.GroupJpaRepositoryCustom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +9,6 @@ import org.springframework.stereotype.Repository;
 
 
 @Repository
-public interface GroupJpaRepository extends JpaRepository<Group, Long> {
+public interface GroupJpaRepository extends JpaRepository<Group, Long>, GroupJpaRepositoryCustom {
     Page<Group> findBySchoolOrderByIdDesc(Pageable pageable, String school);
 }

--- a/src/main/java/com/gloddy/server/group/repository/UserGroupJpaRepository.java
+++ b/src/main/java/com/gloddy/server/group/repository/UserGroupJpaRepository.java
@@ -1,7 +1,8 @@
 package com.gloddy.server.group.repository;
 
 import com.gloddy.server.group.entity.UserGroup;
+import com.gloddy.server.group.repository.custom.UserGroupJpaRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserGroupJpaRepository extends JpaRepository<UserGroup, Long> {
+public interface UserGroupJpaRepository extends JpaRepository<UserGroup, Long>, UserGroupJpaRepositoryCustom {
 }

--- a/src/main/java/com/gloddy/server/group/repository/UserGroupJpaRepository.java
+++ b/src/main/java/com/gloddy/server/group/repository/UserGroupJpaRepository.java
@@ -4,5 +4,8 @@ import com.gloddy.server.group.entity.UserGroup;
 import com.gloddy.server.group.repository.custom.UserGroupJpaRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserGroupJpaRepository extends JpaRepository<UserGroup, Long>, UserGroupJpaRepositoryCustom {
+    Optional<UserGroup> findByUserIdAndGroupId(Long userId, Long groupId);
 }

--- a/src/main/java/com/gloddy/server/group/repository/UserGroupJpaRepository.java
+++ b/src/main/java/com/gloddy/server/group/repository/UserGroupJpaRepository.java
@@ -1,0 +1,7 @@
+package com.gloddy.server.group.repository;
+
+import com.gloddy.server.group.entity.UserGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserGroupJpaRepository extends JpaRepository<UserGroup, Long> {
+}

--- a/src/main/java/com/gloddy/server/group/repository/custom/GroupJpaRepositoryCustom.java
+++ b/src/main/java/com/gloddy/server/group/repository/custom/GroupJpaRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.gloddy.server.group.repository.custom;
+
+public interface GroupJpaRepositoryCustom {
+}

--- a/src/main/java/com/gloddy/server/group/repository/custom/UserGroupJpaRepositoryCustom.java
+++ b/src/main/java/com/gloddy/server/group/repository/custom/UserGroupJpaRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.gloddy.server.group.repository.custom;
 
 import com.gloddy.server.auth.entity.User;
 import com.gloddy.server.group.entity.Group;
+import com.gloddy.server.group.entity.UserGroup;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,5 +12,5 @@ public interface UserGroupJpaRepositoryCustom {
 
     List<Group> findExpectedGroupsByUser(User user);
 
-    Page<Group> findParticipatedGroupsByUser(User user, Pageable pageable);
+    Page<UserGroup> findParticipatedGroupsByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/gloddy/server/group/repository/custom/UserGroupJpaRepositoryCustom.java
+++ b/src/main/java/com/gloddy/server/group/repository/custom/UserGroupJpaRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.gloddy.server.group.repository.custom;
+
+import com.gloddy.server.auth.entity.User;
+import com.gloddy.server.group.entity.Group;
+
+import java.util.List;
+
+public interface UserGroupJpaRepositoryCustom {
+
+    List<Group> findExpectedGroupsByUser(User user);
+}

--- a/src/main/java/com/gloddy/server/group/repository/custom/UserGroupJpaRepositoryCustom.java
+++ b/src/main/java/com/gloddy/server/group/repository/custom/UserGroupJpaRepositoryCustom.java
@@ -2,10 +2,14 @@ package com.gloddy.server.group.repository.custom;
 
 import com.gloddy.server.auth.entity.User;
 import com.gloddy.server.group.entity.Group;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface UserGroupJpaRepositoryCustom {
 
     List<Group> findExpectedGroupsByUser(User user);
+
+    Page<Group> findParticipatedGroupsByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/gloddy/server/group/repository/impl/GroupJpaRepositoryImpl.java
+++ b/src/main/java/com/gloddy/server/group/repository/impl/GroupJpaRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.gloddy.server.group.repository.impl;
+
+import com.gloddy.server.group.repository.custom.GroupJpaRepositoryCustom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GroupJpaRepositoryImpl implements GroupJpaRepositoryCustom {
+
+    private final JPAQueryFactory query;
+}

--- a/src/main/java/com/gloddy/server/group/repository/impl/UserGroupJpaRepositoryImpl.java
+++ b/src/main/java/com/gloddy/server/group/repository/impl/UserGroupJpaRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.gloddy.server.group.repository.impl;
+
+import com.gloddy.server.auth.entity.User;
+import com.gloddy.server.group.entity.Group;
+import com.gloddy.server.group.repository.custom.UserGroupJpaRepositoryCustom;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.gloddy.server.group.entity.QGroup.group;
+import static com.gloddy.server.group.entity.QUserGroup.userGroup;
+
+@Repository
+@RequiredArgsConstructor
+public class UserGroupJpaRepositoryImpl implements UserGroupJpaRepositoryCustom {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<Group> findExpectedGroupsByUser(User user) {
+        return query.select(group)
+            .from(userGroup)
+            .join(userGroup.group, group)
+            .where(userEq(user), startTimeAfter(LocalDateTime.now()))
+            .orderBy(group.id.desc())
+            .fetch();
+    }
+
+    private BooleanExpression userEq(User user) {
+        return userGroup.user.eq(user);
+    }
+
+    private BooleanExpression startTimeAfter(LocalDateTime limit) {
+        return userGroup.group.startTime.after(limit);
+    }
+}

--- a/src/main/java/com/gloddy/server/group/repository/impl/UserGroupJpaRepositoryImpl.java
+++ b/src/main/java/com/gloddy/server/group/repository/impl/UserGroupJpaRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.gloddy.server.group.repository.impl;
 
 import com.gloddy.server.auth.entity.User;
 import com.gloddy.server.group.entity.Group;
+import com.gloddy.server.group.entity.UserGroup;
 import com.gloddy.server.group.repository.custom.UserGroupJpaRepositoryCustom;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -34,8 +35,8 @@ public class UserGroupJpaRepositoryImpl implements UserGroupJpaRepositoryCustom 
     }
 
     @Override
-    public Page<Group> findParticipatedGroupsByUser(User user, Pageable pageable) {
-        List<Group> groups = query.select(group)
+    public Page<UserGroup> findParticipatedGroupsByUser(User user, Pageable pageable) {
+        List<UserGroup> groups = query.select(userGroup)
                 .from(userGroup)
                 .join(userGroup.group, group)
                 .where(userEq(user), startTimeBefore(LocalDateTime.now()))

--- a/src/main/java/com/gloddy/server/group/service/GroupService.java
+++ b/src/main/java/com/gloddy/server/group/service/GroupService.java
@@ -8,6 +8,7 @@ import com.gloddy.server.user.repository.UserRepository;
 import com.gloddy.server.core.error.handler.errorCode.ErrorCode;
 import com.gloddy.server.core.error.handler.exception.UserBusinessException;
 import com.gloddy.server.core.response.PageResponse;
+import com.gloddy.server.core.utils.DateTimeUtils;
 import com.gloddy.server.domain.GroupApplies;
 import com.gloddy.server.domain.GroupUsers;
 import com.gloddy.server.group.dto.GroupRequest;
@@ -71,9 +72,18 @@ public class GroupService {
                 .fileUrl(req.getFileUrl())
                 .title(req.getTitle())
                 .content(req.getContent())
-                .meetDate(req.getMeetDate())
-                .startTime(req.getStartTime())
-                .endTime(req.getEndTime())
+                .startTime(
+                        DateTimeUtils.concatDateAndTime(
+                                req.getMeetDate(),
+                                DateTimeUtils.StringToLocalTime(req.getStartTime())
+                        )
+                )
+                .endTime(
+                        DateTimeUtils.concatDateAndTime(
+                                req.getMeetDate(),
+                                DateTimeUtils.StringToLocalTime(req.getEndTime())
+                        )
+                )
                 .place(req.getPlace())
                 .placeLatitude(req.getPlace_latitude())
                 .placeLongitude(req.getPlace_longitude())
@@ -116,8 +126,8 @@ public class GroupService {
                 groupUsers.getUserCount(),
                 groupUsers.getUserInfoDtos(),
                 dateTimeFormatter(groupUsers.getGroup().getMeetDate()),
-                groupUsers.getGroup().getStartTime(),
-                groupUsers.getGroup().getEndTime(),
+                groupUsers.getGroup().getStartTime().toLocalTime().toString(),
+                groupUsers.getGroup().getEndTime().toLocalTime().toString(),
                 groupUsers.getGroup().getPlace(),
                 groupUsers.getGroup().getPlaceLatitude(),
                 groupUsers.getGroup().getPlaceLongitude()

--- a/src/main/java/com/gloddy/server/group/service/MyGroupService.java
+++ b/src/main/java/com/gloddy/server/group/service/MyGroupService.java
@@ -28,11 +28,11 @@ public class MyGroupService {
            .collect(Collectors.collectingAndThen(Collectors.toList(), GroupResponse.GetGroups::new));
     }
 
-    public PageResponse<GroupResponse.GetGroup> getParticipatedMyGroup(Long userId, int page, int size) {
+    public PageResponse<GroupResponse.GetParticipatedGroup> getParticipatedMyGroup(Long userId, int page, int size) {
         User findUser = userFindService.findById(userId);
         return PageResponse.from(
            userGroupJpaRepository.findParticipatedGroupsByUser(findUser, PageRequest.of(page, size))
-           .map(GroupResponse.GetGroup::from)
+           .map(GroupResponse.GetParticipatedGroup::from)
         );
     }
 }

--- a/src/main/java/com/gloddy/server/group/service/MyGroupService.java
+++ b/src/main/java/com/gloddy/server/group/service/MyGroupService.java
@@ -1,0 +1,28 @@
+package com.gloddy.server.group.service;
+
+import com.gloddy.server.auth.entity.User;
+import com.gloddy.server.group.dto.GroupResponse;
+import com.gloddy.server.group.entity.Group;
+import com.gloddy.server.group.repository.UserGroupJpaRepository;
+import com.gloddy.server.user.service.UserFindService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MyGroupService {
+
+    private final UserFindService userFindService;
+    private final UserGroupJpaRepository userGroupJpaRepository;
+
+    public List<GroupResponse.GetGroup> getExpectedMyGroup(Long userId) {
+        User findUser = userFindService.findById(userId);
+        List<Group> expectedMyGroups = userGroupJpaRepository.findExpectedGroupsByUser(findUser);
+        return expectedMyGroups.stream()
+           .map(GroupResponse.GetGroup::from)
+           .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/src/main/java/com/gloddy/server/group/service/MyGroupService.java
+++ b/src/main/java/com/gloddy/server/group/service/MyGroupService.java
@@ -1,11 +1,13 @@
 package com.gloddy.server.group.service;
 
 import com.gloddy.server.auth.entity.User;
+import com.gloddy.server.core.response.PageResponse;
 import com.gloddy.server.group.dto.GroupResponse;
 import com.gloddy.server.group.entity.Group;
 import com.gloddy.server.group.repository.UserGroupJpaRepository;
 import com.gloddy.server.user.service.UserFindService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -18,11 +20,19 @@ public class MyGroupService {
     private final UserFindService userFindService;
     private final UserGroupJpaRepository userGroupJpaRepository;
 
-    public List<GroupResponse.GetGroup> getExpectedMyGroup(Long userId) {
+    public GroupResponse.GetGroups getExpectedMyGroup(Long userId) {
         User findUser = userFindService.findById(userId);
         List<Group> expectedMyGroups = userGroupJpaRepository.findExpectedGroupsByUser(findUser);
         return expectedMyGroups.stream()
            .map(GroupResponse.GetGroup::from)
-           .collect(Collectors.toUnmodifiableList());
+           .collect(Collectors.collectingAndThen(Collectors.toList(), GroupResponse.GetGroups::new));
+    }
+
+    public PageResponse<GroupResponse.GetGroup> getParticipatedMyGroup(Long userId, int page, int size) {
+        User findUser = userFindService.findById(userId);
+        return PageResponse.from(
+           userGroupJpaRepository.findParticipatedGroupsByUser(findUser, PageRequest.of(page, size))
+           .map(GroupResponse.GetGroup::from)
+        );
     }
 }

--- a/src/main/java/com/gloddy/server/group/service/UserGroupSaveService.java
+++ b/src/main/java/com/gloddy/server/group/service/UserGroupSaveService.java
@@ -22,6 +22,7 @@ public class UserGroupSaveService {
         User findUser = userFindService.findById(userId);
         UserGroup userGroup = UserGroup.empty();
         userGroup.init(findUser, findGroup);
+        findGroup.addUserGroup(userGroup);
         return userGroupJpaRepository.save(userGroup);
     }
 }

--- a/src/main/java/com/gloddy/server/group/service/UserGroupSaveService.java
+++ b/src/main/java/com/gloddy/server/group/service/UserGroupSaveService.java
@@ -1,11 +1,11 @@
 package com.gloddy.server.group.service;
 
 import com.gloddy.server.auth.entity.User;
-import com.gloddy.server.auth.service.UserFindService;
 import com.gloddy.server.group.entity.Group;
 import com.gloddy.server.group.entity.UserGroup;
 import com.gloddy.server.group.handler.GroupQueryHandler;
 import com.gloddy.server.group.repository.UserGroupJpaRepository;
+import com.gloddy.server.user.service.UserFindService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/gloddy/server/group/service/UserGroupSaveService.java
+++ b/src/main/java/com/gloddy/server/group/service/UserGroupSaveService.java
@@ -1,0 +1,27 @@
+package com.gloddy.server.group.service;
+
+import com.gloddy.server.auth.entity.User;
+import com.gloddy.server.auth.service.UserFindService;
+import com.gloddy.server.group.entity.Group;
+import com.gloddy.server.group.entity.UserGroup;
+import com.gloddy.server.group.handler.GroupQueryHandler;
+import com.gloddy.server.group.repository.UserGroupJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserGroupSaveService {
+
+    private final GroupQueryHandler groupQueryHandler;
+    private final UserFindService userFindService;
+    private final UserGroupJpaRepository userGroupJpaRepository;
+
+    public UserGroup saveUserGroup(Long userId, Long groupId) {
+        Group findGroup = groupQueryHandler.findById(groupId);
+        User findUser = userFindService.findById(userId);
+        UserGroup userGroup = UserGroup.empty();
+        userGroup.init(findUser, findGroup);
+        return userGroupJpaRepository.save(userGroup);
+    }
+}

--- a/src/main/java/com/gloddy/server/group/service/UserGroupUpdateService.java
+++ b/src/main/java/com/gloddy/server/group/service/UserGroupUpdateService.java
@@ -1,0 +1,20 @@
+package com.gloddy.server.group.service;
+
+import com.gloddy.server.group.entity.UserGroup;
+import com.gloddy.server.group.repository.UserGroupJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserGroupUpdateService {
+    private final UserGroupJpaRepository userGroupJpaRepository;
+
+    @Transactional
+    public void completePraise(Long userId, Long groupId) {
+        UserGroup findUserGroup = userGroupJpaRepository.findByUserIdAndGroupId(userId, groupId)
+                .orElseThrow(() -> new RuntimeException("not found UserGroup"));
+        findUserGroup.completePraise();
+    }
+}

--- a/src/test/java/com/gloddy/server/acceptance/group/GetExpectedGroupTest.java
+++ b/src/test/java/com/gloddy/server/acceptance/group/GetExpectedGroupTest.java
@@ -1,0 +1,45 @@
+package com.gloddy.server.acceptance.group;
+
+import com.gloddy.server.common.group.GroupApiTest;
+import com.gloddy.server.group.entity.Group;
+import com.gloddy.server.group.entity.UserGroup;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class GetExpectedGroupTest extends GroupApiTest {
+
+    @Test
+    @DisplayName("success_getExpetedGroup")
+    void successGetExpectedGroup() throws Exception {
+        //given
+        //로그인된 사용자이다.
+        Group mockGroup = createGroup();
+        Group expectedGroup = createExpectedGroup();
+        Group participatedGroup = createParticipatedGroup();
+
+        createUserGroup(user, mockGroup);
+        createUserGroup(user, expectedGroup);
+        createUserGroup(user, participatedGroup);
+
+        //when
+        //참여할 그룹 조회 API를 날린다.
+        ResultActions test = mockMvc.perform(
+                get("/api/v1/groups/my-expected")
+                .header("X-AUTH-TOKEN", accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+        //then
+        //참여할 그룹이 조회된다.
+        test.andExpect(status().isOk());
+        test.andExpect(jsonPath("groups.size()").value(1));
+        test.andExpect(jsonPath("groups[0].groupId").value(expectedGroup.getId()));
+        test.andExpect(jsonPath("groups[0].meetDate").value(expectedGroup.getMeetDate().toString()));
+    }
+
+}

--- a/src/test/java/com/gloddy/server/acceptance/group/GetParticipatedGroupTest.java
+++ b/src/test/java/com/gloddy/server/acceptance/group/GetParticipatedGroupTest.java
@@ -1,0 +1,43 @@
+package com.gloddy.server.acceptance.group;
+
+import com.gloddy.server.common.group.GroupApiTest;
+import com.gloddy.server.group.entity.Group;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+public class GetParticipatedGroupTest extends GroupApiTest {
+
+    @Test
+    @DisplayName("success_getParticipatedGroup")
+    void successGeParticipatedGroup() throws Exception {
+        //given
+        //로그인 된 사용자이다.
+        Group mockGroup = createGroup();
+        Group expectedGroup = createExpectedGroup();
+        Group participatedGroup = createParticipatedGroup();
+
+        createUserGroup(user, mockGroup);
+        createUserGroup(user, expectedGroup);
+        createUserGroup(user, participatedGroup);
+
+        //when
+        //참여했던 그룹 조회 API를 날린다.
+        ResultActions test = mockMvc.perform(
+                get("/api/v1/groups/my-participated?page=0&size=5")
+                .header("X-AUTH-TOKEN", accessToken));
+
+        //then
+        //참여했던 그룹이 조회된다.
+        test.andExpect(jsonPath("totalCount").value(1));
+        test.andExpect(jsonPath("currentCount").value(1));
+        test.andExpect(jsonPath("currentPage").value(0));
+        test.andExpect(jsonPath("currentPage").value(0));
+        test.andExpect(jsonPath("totalPage").value(1));
+        test.andExpect(jsonPath("contents[0].groupId").value(participatedGroup.getId()));
+        test.andExpect(jsonPath("contents[0].meetDate").value(participatedGroup.getMeetDate().toString()));
+    }
+}

--- a/src/test/java/com/gloddy/server/acceptance/group/GetParticipatedGroupTest.java
+++ b/src/test/java/com/gloddy/server/acceptance/group/GetParticipatedGroupTest.java
@@ -2,6 +2,7 @@ package com.gloddy.server.acceptance.group;
 
 import com.gloddy.server.common.group.GroupApiTest;
 import com.gloddy.server.group.entity.Group;
+import com.gloddy.server.group.entity.UserGroup;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.ResultActions;
@@ -18,11 +19,13 @@ public class GetParticipatedGroupTest extends GroupApiTest {
         //로그인 된 사용자이다.
         Group mockGroup = createGroup();
         Group expectedGroup = createExpectedGroup();
-        Group participatedGroup = createParticipatedGroup();
+        Group participatedGroup1 = createParticipatedGroup();
+        Group participatedGroup2 = createParticipatedGroup();
 
         createUserGroup(user, mockGroup);
         createUserGroup(user, expectedGroup);
-        createUserGroup(user, participatedGroup);
+        createUserGroup(user, participatedGroup1);
+        createCompletePraiseUserGroup(user, participatedGroup2);
 
         //when
         //참여했던 그룹 조회 API를 날린다.
@@ -32,12 +35,17 @@ public class GetParticipatedGroupTest extends GroupApiTest {
 
         //then
         //참여했던 그룹이 조회된다.
-        test.andExpect(jsonPath("totalCount").value(1));
-        test.andExpect(jsonPath("currentCount").value(1));
+        //참여했던 그룹의 칭찬여부 또한 조회된다.
+        test.andExpect(jsonPath("totalCount").value(2));
+        test.andExpect(jsonPath("currentCount").value(2));
         test.andExpect(jsonPath("currentPage").value(0));
         test.andExpect(jsonPath("currentPage").value(0));
         test.andExpect(jsonPath("totalPage").value(1));
-        test.andExpect(jsonPath("contents[0].groupId").value(participatedGroup.getId()));
-        test.andExpect(jsonPath("contents[0].meetDate").value(participatedGroup.getMeetDate().toString()));
+        test.andExpect(jsonPath("contents[0].groupId").value(participatedGroup2.getId()));
+        test.andExpect(jsonPath("contents[0].meetDate").value(participatedGroup2.getMeetDate().toString()));
+        test.andExpect(jsonPath("contents[0].praised").value(true));
+        test.andExpect(jsonPath("contents[1].groupId").value(participatedGroup1.getId()));
+        test.andExpect(jsonPath("contents[1].meetDate").value(participatedGroup1.getMeetDate().toString()));
+        test.andExpect(jsonPath("contents[1].praised").value(false));
     }
 }

--- a/src/test/java/com/gloddy/server/common/BaseApiTest.java
+++ b/src/test/java/com/gloddy/server/common/BaseApiTest.java
@@ -1,0 +1,62 @@
+package com.gloddy.server.common;
+
+import com.gloddy.server.auth.entity.User;
+import com.gloddy.server.auth.entity.kind.Personality;
+import com.gloddy.server.auth.jwt.JwtTokenBuilder;
+import com.gloddy.server.estimate.entity.Praise;
+import com.gloddy.server.estimate.repository.PraiseJpaRepository;
+import com.gloddy.server.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+abstract public class BaseApiTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected JwtTokenBuilder jwtTokenBuilder;
+
+    @Autowired
+    protected UserRepository userRepository;
+
+    @Autowired
+    protected PraiseJpaRepository praiseJpaRepository;
+
+    protected String testUserEmail = "testEmail@soogsil.ac.kr";
+    protected String accessToken;
+    protected User user;
+
+    protected Praise createPraise(User user) {
+        Praise mockPraise = Praise.empty();
+        mockPraise.init(user);
+        return praiseJpaRepository.save(mockPraise);
+    }
+
+    protected User createUser() {
+        User mockUser = User.builder().email(testUserEmail).
+                personalities(List.of(Personality.KIND)).build();
+        return userRepository.save(mockUser);
+    }
+
+    protected String getTokenAfterLogin(User user) {
+        return jwtTokenBuilder.createToken(user.getEmail());
+    }
+
+    @BeforeEach
+    void setUp() {
+        User mockUser = createUser();
+        createPraise(mockUser);
+        accessToken = getTokenAfterLogin(mockUser);
+        user = mockUser;
+    }
+}

--- a/src/test/java/com/gloddy/server/common/group/GroupApiTest.java
+++ b/src/test/java/com/gloddy/server/common/group/GroupApiTest.java
@@ -1,0 +1,42 @@
+package com.gloddy.server.common.group;
+
+import com.gloddy.server.auth.entity.User;
+import com.gloddy.server.common.BaseApiTest;
+import com.gloddy.server.group.entity.Group;
+import com.gloddy.server.group.entity.UserGroup;
+import com.gloddy.server.group.repository.GroupJpaRepository;
+import com.gloddy.server.group.repository.UserGroupJpaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+abstract public class GroupApiTest extends BaseApiTest {
+
+    @Autowired
+    protected GroupJpaRepository groupJpaRepository;
+
+    @Autowired
+    protected UserGroupJpaRepository userGroupJpaRepository;
+
+    protected Group createGroup() {
+        Group group = Group.builder().build();
+        return groupJpaRepository.save(group);
+    }
+
+    protected UserGroup createUserGroup(User user, Group group) {
+        UserGroup userGroup = UserGroup.empty();
+        userGroup.init(user, group);
+        group.addUserGroup(userGroup);
+        return userGroupJpaRepository.save(userGroup);
+    }
+
+    protected Group createExpectedGroup() {
+        Group expectedGroup = Group.builder().startTime(LocalDateTime.now().plusDays(1L)).build();
+        return groupJpaRepository.save(expectedGroup);
+    }
+
+    protected Group createParticipatedGroup() {
+        Group participatedGroup = Group.builder().startTime(LocalDateTime.now().minusDays(1L)).build();
+        return groupJpaRepository.save(participatedGroup);
+    }
+}

--- a/src/test/java/com/gloddy/server/common/group/GroupApiTest.java
+++ b/src/test/java/com/gloddy/server/common/group/GroupApiTest.java
@@ -30,6 +30,14 @@ abstract public class GroupApiTest extends BaseApiTest {
         return userGroupJpaRepository.save(userGroup);
     }
 
+    protected UserGroup createCompletePraiseUserGroup(User user, Group group) {
+        UserGroup userGroup = UserGroup.empty();
+        userGroup.init(user, group);
+        group.addUserGroup(userGroup);
+        userGroup.completePraise();
+        return userGroupJpaRepository.save(userGroup);
+    }
+
     protected Group createExpectedGroup() {
         Group expectedGroup = Group.builder().startTime(LocalDateTime.now().plusDays(1L)).build();
         return groupJpaRepository.save(expectedGroup);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,49 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:gloddy;MODE=MYSQL;DATABASE_TO_UPPER=false
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: dummy-username
+    password: dummy-password
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+
+  redis:
+    host: dummy-host
+    port: 9999
+
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+jwt:
+  header: X-AUTH-TOKEN
+  secret: testJwtSecret-testJwtSecret-testJwtSecret-testJwtSecret-testJwtSecret-testJwtSecret
+  validTime: 3600000
+
+cloud:
+  aws:
+    credentials:
+      access-key: dummy-key
+      secret-key: dummy-key
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+
+aws:
+  s3:
+    bucket: dummy-bucket


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #0
### 작업 사항
- UserGroup Entity 생성 - Apply를 통해서 그룹 관련 로직을 짯는데 가독성 및 컬럼 문제로 UserGroup으로 하기로 결젱
    - 지원서 승인이 되면, 방장이 그룹을 만들면 UserGroup 생성 - 방장이 그룹을 만들 때 생성 로직은 아직 구현 x
- Querydsl 설정
- 나의 그룹 중 참여 할 그룹 조회 API 로직 구현 및 테스트
- 나의 그룹 중 참여 한 그룹 조회 API 로직 구현 및 테스트
- 이슈 해결
   - user table 명 users로 변경 (h2 user 예약어)
   - group entity의 usergroup embedded 객체 NPE 해결
   - 칭찬 트랜잭션 서비스 로직 마지막에 칭찬 완료했다는 로직 추가
- DDL
```sql
create table user_group(
    id bigint auto_increment,
    user_id bigint ,
    group_id bigint,
    is_end bit(1),
    is_praised bit(1),
    primary key (id),
    foreign key (user_id) references user(id),
    foreign key (group_id) references `group`(id)
);
alter table user rename users;
```

