### PR TITLE
[FIX]: Spring Data Redis yml 변경 및 파일 업로드 API Open

### DIFF
--- a/src/main/java/com/gloddy/server/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/gloddy/server/auth/security/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/*/**")
+                .requestMatchers(HttpMethod.POST, "/api/v1/files/**")
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/*/**");
     }
 

--- a/src/main/java/com/gloddy/server/file/api/FileApi.java
+++ b/src/main/java/com/gloddy/server/file/api/FileApi.java
@@ -4,6 +4,7 @@ import com.gloddy.server.file.dto.FileResponse;
 import com.gloddy.server.file.service.FileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,6 +15,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 @RestController
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class FileApi {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,9 +29,10 @@ spring:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
 
-  redis:
-    host: ${REDISHOST}
-    port: ${REDISPORT}
+  data:
+    redis:
+      host: ${REDISHOST}
+      port: ${REDISPORT}
 
   mvc:
     pathmatch:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -22,9 +22,10 @@ spring:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
 
-  redis:
-    host: dummy-host
-    port: 9999
+  data:
+    redis:
+      host: dummy-host
+      port: 9999
 
   mvc:
     pathmatch:


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #0
### 작업 사항
- Spring Boot 3.0.3 이상 버전에 맞는 Spring Data Redis yml 파일 설정 변경
   - https://docs.spring.io/spring-boot/docs/3.0.3/reference/html/data.html#data.nosql.redis
- 파일 업로드 API Open (No Security)