### PR TITLE
[FIX]: 회원가입 시 이미 가입된 유저 차단

### DIFF
--- a/src/main/java/com/gloddy/server/auth/domain/service/UserFactory.java
+++ b/src/main/java/com/gloddy/server/auth/domain/service/UserFactory.java
@@ -3,14 +3,20 @@ package com.gloddy.server.auth.domain.service;
 import com.gloddy.server.auth.domain.User;
 import com.gloddy.server.auth.domain.vo.Phone;
 import com.gloddy.server.auth.domain.vo.School;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import static com.gloddy.server.auth.domain.dto.AuthRequest.*;
 
 @Component
+@RequiredArgsConstructor
 public class UserFactory {
 
+    private final UserSignUpPolicy userSignUpPolicy;
+
     public User getUser(SignUp request) {
+        userSignUpPolicy.validate(request.getPhoneNumber());
+
         Phone phone = getPhone(request.getPhoneNumber());
         School school = getSchool(request.getSchoolInfo());
         return User.builder()

--- a/src/main/java/com/gloddy/server/auth/domain/service/UserSignUpPolicy.java
+++ b/src/main/java/com/gloddy/server/auth/domain/service/UserSignUpPolicy.java
@@ -1,0 +1,27 @@
+package com.gloddy.server.auth.domain.service;
+
+import com.gloddy.server.auth.domain.User;
+import com.gloddy.server.auth.domain.vo.Phone;
+import com.gloddy.server.auth.exception.AlreadyUserSignUpException;
+import com.gloddy.server.user.infra.repository.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class UserSignUpPolicy {
+
+    private final UserJpaRepository userJpaRepository;
+
+    public void validate(String phoneNumber) {
+        Phone phone = new Phone(phoneNumber);
+
+        Optional<User> user = userJpaRepository.findByPhone(phone);
+
+        if (user.isPresent()) {
+            throw new AlreadyUserSignUpException();
+        }
+    }
+}

--- a/src/main/java/com/gloddy/server/auth/domain/vo/Phone.java
+++ b/src/main/java/com/gloddy/server/auth/domain/vo/Phone.java
@@ -18,7 +18,7 @@ public class Phone {
 
     private static final String DELIMITER = "-";
 
-    @Column(name = "phone_number")
+    @Column(name = "phone_number", unique = true)
     private String phoneNumber;
 
     public Phone(String phone) {

--- a/src/main/java/com/gloddy/server/auth/exception/AlreadyUserSignUpException.java
+++ b/src/main/java/com/gloddy/server/auth/exception/AlreadyUserSignUpException.java
@@ -1,0 +1,10 @@
+package com.gloddy.server.auth.exception;
+
+import com.gloddy.server.core.error.handler.errorCode.ErrorCode;
+import com.gloddy.server.core.error.handler.exception.UserBusinessException;
+
+public class AlreadyUserSignUpException extends UserBusinessException {
+    public AlreadyUserSignUpException() {
+        super(ErrorCode.ALREADY_USER_SIGN_UP);
+    }
+}

--- a/src/main/java/com/gloddy/server/core/error/handler/errorCode/ErrorCode.java
+++ b/src/main/java/com/gloddy/server/core/error/handler/errorCode/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     TOKEN_EXPIRED(412, "토큰이 만료되었습니다."),
 
     USER_NOT_FOUND(404, "존재하지 않는 유저입니다."),
+    ALREADY_USER_SIGN_UP(400, "이미 가입된 유저입니다."),
     INVALID_PHONE_NUMBER(400, "유효하지 않은 전화번호 입니다."),
     PASSWORD_DISCORD(404, "패스워드가 일치하지 않습니다."),
 


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #0
### 작업 사항
- UX 플로우 상(로그인 -> 이미 가입된 회원이면 로그인 성공 -> 가입되지 않은 회원이면 회원가입 절차 진행) 이미 가입된 회원은 다시 회원가입이 되지 않지만, 혹시 모를 예외 상황이 발생할 수 있고, 이후 Auth 플로우에 대한 변경이 있을 수 있기 때문에 데이터 정합성을 지키기 위해 백엔드 회원가입 로직에도 검증 로직 추가
   - `UserSignUpPolicy` Domain Service 구현
   -  User Domain 필드 중 phone에 대한 필드 unique 제약 조건 추가