### PR TITLE
[FEAT]: Security Filter 단 예외 핸들링 (JWT)

### DIFF
--- a/src/main/java/com/gloddy/server/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gloddy/server/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -3,7 +3,6 @@ package com.gloddy.server.auth.jwt.filter;
 import com.gloddy.server.auth.jwt.JwtAuthentication;
 import com.gloddy.server.auth.jwt.JwtTokenExtractor;
 import com.gloddy.server.auth.jwt.JwtTokenValidator;
-import com.gloddy.server.core.error.handler.errorCode.ErrorCode;
 import com.gloddy.server.core.error.handler.exception.UserBusinessException;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -20,6 +19,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+import static com.gloddy.server.core.error.handler.errorCode.ErrorCode.*;
 
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -48,7 +48,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             String token = jwtTokenExtractor.extractToken(request, TOKEN_HEADER);
             if (jwtTokenValidator.validateToken(token)) {
-                throw new UserBusinessException(ErrorCode.TOKEN_BLANK);
+                throw new UserBusinessException(TOKEN_BLANK);
             }
 
             String phoneNumber = jwtTokenExtractor.extractPhoneNumberFromToken(token, KEY);
@@ -61,11 +61,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             filterChain.doFilter(request, response);
         } catch (UnsupportedJwtException | MalformedJwtException e) {
-            throw new UserBusinessException(ErrorCode.TOKEN_INVALID);
+            throw new UserBusinessException(TOKEN_INVALID);
         } catch (ExpiredJwtException e) {
-            throw new UserBusinessException(ErrorCode.TOKEN_EXPIRED);
+            throw new UserBusinessException(TOKEN_EXPIRED);
         } catch (ServletException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(e.getMessage());
         }
 
     }

--- a/src/main/java/com/gloddy/server/auth/jwt/filter/JwtExceptionHandleFilter.java
+++ b/src/main/java/com/gloddy/server/auth/jwt/filter/JwtExceptionHandleFilter.java
@@ -1,0 +1,54 @@
+package com.gloddy.server.auth.jwt.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.gloddy.server.core.error.handler.exception.UserBusinessException;
+import com.gloddy.server.core.response.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtExceptionHandleFilter extends OncePerRequestFilter {
+
+    public JwtExceptionHandleFilter() {
+
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception exception) {
+            ErrorResponse errorResponse = createErrorResponse(exception);
+            String errorJson = convertToJson(errorResponse);
+
+            response.setCharacterEncoding("UTF-8");
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setStatus(errorResponse.getStatus());
+            response.getWriter().println(errorJson);
+        }
+    }
+
+    private ErrorResponse createErrorResponse(Exception exception) {
+        if (exception instanceof UserBusinessException userBusinessException) {
+            return new ErrorResponse(userBusinessException.getErrorCode());
+        } else {
+            return ErrorResponse.of(
+                    HttpStatus.UNAUTHORIZED.value(),
+                    "UNAUTHORIZED",
+                    HttpStatus.UNAUTHORIZED.getReasonPhrase()
+            );
+        }
+    }
+
+    private String convertToJson(ErrorResponse errorResponse) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(errorResponse);
+    }
+}

--- a/src/main/java/com/gloddy/server/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/gloddy/server/auth/security/config/SecurityConfig.java
@@ -15,7 +15,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -32,7 +31,6 @@ public class SecurityConfig {
     private final JwtTokenExtractor jwtTokenExtractor;
     private final JwtTokenValidator jwtTokenValidator;
     private final AuthenticationProvider authenticationProvider;
-    private final AuthenticationEntryPoint authenticationEntryPoint;
     @Value("${jwt.secret}")
     private String key;
     @Value("${jwt.header}")

--- a/src/main/java/com/gloddy/server/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/gloddy/server/auth/security/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.gloddy.server.auth.security.config;
 import com.gloddy.server.auth.jwt.JwtTokenExtractor;
 import com.gloddy.server.auth.jwt.JwtTokenValidator;
 import com.gloddy.server.auth.jwt.filter.JwtAuthenticationFilter;
+import com.gloddy.server.auth.jwt.filter.JwtExceptionHandleFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -14,6 +15,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -30,6 +32,7 @@ public class SecurityConfig {
     private final JwtTokenExtractor jwtTokenExtractor;
     private final JwtTokenValidator jwtTokenValidator;
     private final AuthenticationProvider authenticationProvider;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
     @Value("${jwt.secret}")
     private String key;
     @Value("${jwt.header}")
@@ -55,7 +58,8 @@ public class SecurityConfig {
                         jwtTokenValidator,
                         authenticationProvider,
                         secretHeader,
-                        key), UsernamePasswordAuthenticationFilter.class);
+                        key), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtExceptionHandleFilter(), JwtAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/gloddy/server/core/error/handler/errorCode/ErrorCode.java
+++ b/src/main/java/com/gloddy/server/core/error/handler/errorCode/ErrorCode.java
@@ -9,11 +9,11 @@ public enum ErrorCode {
 
     NULL(000, "no content"),
 
-    TOKEN_INVALID(400, "올바르지 않는 토큰입니다."),
-    TOKEN_ERROR(400, "토큰 자체에 문제가 있습니다."),
-    TOKEN_EMPTY(400, "헤더에 토큰이 존재하지 않습니다."),
-    TOKEN_BLANK(400, "토큰이 비어져 있습니다."),
-    TOKEN_EXPIRED(412, "토큰이 만료되었습니다."),
+    TOKEN_INVALID(403, "올바르지 않는 토큰입니다."),
+    TOKEN_ERROR(403, "토큰 자체에 문제가 있습니다."),
+    TOKEN_EMPTY(403, "헤더에 토큰이 존재하지 않습니다."),
+    TOKEN_BLANK(403, "토큰이 비어져 있습니다."),
+    TOKEN_EXPIRED(403, "토큰이 만료되었습니다."),
 
     USER_NOT_FOUND(404, "존재하지 않는 유저입니다."),
     ALREADY_USER_SIGN_UP(400, "이미 가입된 유저입니다."),

--- a/src/main/java/com/gloddy/server/core/error/handler/exception/UserBusinessException.java
+++ b/src/main/java/com/gloddy/server/core/error/handler/exception/UserBusinessException.java
@@ -2,7 +2,7 @@ package com.gloddy.server.core.error.handler.exception;
 
 import com.gloddy.server.core.error.handler.errorCode.ErrorCode;
 
-public class UserBusinessException extends BaseBusinessException{
+public class UserBusinessException extends BaseBusinessException {
 
     public UserBusinessException(ErrorCode errorCode) {
         super(errorCode);

--- a/src/main/java/com/gloddy/server/core/response/ErrorResponse.java
+++ b/src/main/java/com/gloddy/server/core/response/ErrorResponse.java
@@ -7,20 +7,20 @@ import java.time.LocalDateTime;
 
 @Getter
 public class ErrorResponse {
-    private final LocalDateTime timestamp;
+    private final String timestamp;
     private final int status;
     private final String message;
     private final String reason;
 
     public ErrorResponse(ErrorCode errorCode) {
-        this.timestamp = LocalDateTime.now();
+        this.timestamp = LocalDateTime.now().toString();
         this.status = errorCode.getStatus();
         this.message = errorCode.name();
         this.reason = errorCode.getErrorMessage();
     }
 
     private ErrorResponse(int status, String message, String reason){
-        this.timestamp = LocalDateTime.now();
+        this.timestamp = LocalDateTime.now().toString();
         this.status = status;
         this.message = message;
         this.reason = reason;

--- a/src/test/java/com/gloddy/server/acceptance/auth/TokenFailTest.java
+++ b/src/test/java/com/gloddy/server/acceptance/auth/TokenFailTest.java
@@ -1,0 +1,100 @@
+package com.gloddy.server.acceptance.auth;
+
+import com.gloddy.server.auth.jwt.payload.AccessPayload;
+import com.gloddy.server.common.auth.AuthApiTest;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+
+import static com.gloddy.server.core.error.handler.errorCode.ErrorCode.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class TokenFailTest extends AuthApiTest {
+
+    @Value("${jwt.secret}")
+    private String key;
+
+    private String createExpiredAccessToken() {
+        AccessPayload accessPayload = AccessPayload.of(user.getPhone().toString());
+
+        Date now = new Date();
+
+        Map<String, Object> claims = accessPayload.createClaims();
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(now)
+                .signWith(getSigningKey(key), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private Key getSigningKey(String secretKey) {
+        byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    private ResultActions apiCall(String accessToken) throws Exception {
+        return mockMvc.perform(
+                get("/me/page")
+                .header("X-AUTH-TOKEN", accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+    }
+
+    private ResultActions apiCallWithNoToken() throws Exception {
+        return mockMvc.perform(
+                get("/me/page")
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+    }
+
+    @Test
+    @DisplayName("Fail - Token Expire")
+    void failByTokenExpire() throws Exception {
+        String expiredAccessToken = createExpiredAccessToken();
+
+        ResultActions test = apiCall(expiredAccessToken);
+
+        test.andExpect(status().isForbidden());
+        test.andExpect(jsonPath("status").value(TOKEN_EXPIRED.getStatus()));
+        test.andExpect(jsonPath("message").value(TOKEN_EXPIRED.name()));
+        test.andExpect(jsonPath("reason").value(TOKEN_EXPIRED.getErrorMessage()));
+    }
+
+    @Test
+    @DisplayName("Fail - Token Blank")
+    void failByTokenBlank() throws Exception {
+        ResultActions test = apiCallWithNoToken();
+
+        test.andExpect(status().isForbidden());
+        test.andExpect(jsonPath("status").value(TOKEN_BLANK.getStatus()));
+        test.andExpect(jsonPath("message").value(TOKEN_BLANK.name()));
+        test.andExpect(jsonPath("reason").value(TOKEN_BLANK.getErrorMessage()));
+    }
+
+    @Test
+    @DisplayName("FAIL - Token Invalid")
+    void failByTokenInvalid() throws Exception {
+        String invalidToken = "token";
+
+        ResultActions test = apiCall(invalidToken);
+
+        test.andExpect(status().isForbidden());
+        test.andExpect(jsonPath("status").value(TOKEN_INVALID.getStatus()));
+        test.andExpect(jsonPath("message").value(TOKEN_INVALID.name()));
+        test.andExpect(jsonPath("reason").value(TOKEN_INVALID.getErrorMessage()));
+    }
+}

--- a/src/test/java/com/gloddy/server/common/auth/AuthApiTest.java
+++ b/src/test/java/com/gloddy/server/common/auth/AuthApiTest.java
@@ -1,0 +1,6 @@
+package com.gloddy.server.common.auth;
+
+import com.gloddy.server.common.BaseApiTest;
+
+abstract public class AuthApiTest extends BaseApiTest {
+}


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #0
### 작업 사항
- Security Filter 단의 예외 핸들링 작업을 하였습니다.
- `JwtAuthenticationFilter` 앞에 `JwtExceptionHandleFilter`를 두어서 예외 핸들링을 하였습니다.
- `AuthenticationEntryPoint`를 사용하려고 했으나, Filter 단에서 예외 발생후 EntryPoint 단에 `AuthenticationException`이 넘어올 때 원하는 Exception이 넘어 오지 않고 InsufficientException이 넘어와서 JwtExceptionHandleFilter를 활용하였습니다. ( 이를 해결하려면 조금 시간이 걸릴 것 같애서 위 방법으로 대체하였습니다.)