### PR TITLE
[FEAT]: 학교 검색 구현

### DIFF
--- a/src/main/java/com/gloddy/server/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/gloddy/server/auth/security/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/*/**")
+                .requestMatchers("/api/v1/search/**")
                 .requestMatchers(HttpMethod.POST, "/api/v1/files/**")
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/*/**")
                 .requestMatchers("/health");

--- a/src/main/java/com/gloddy/server/search/school/School.java
+++ b/src/main/java/com/gloddy/server/search/school/School.java
@@ -1,0 +1,17 @@
+package com.gloddy.server.search.school;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "school")
+public class School {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    private String address;
+}

--- a/src/main/java/com/gloddy/server/search/school/api/SchoolSearchApi.java
+++ b/src/main/java/com/gloddy/server/search/school/api/SchoolSearchApi.java
@@ -1,0 +1,28 @@
+package com.gloddy.server.search.school.api;
+
+import com.gloddy.server.core.response.ApiResponse;
+import com.gloddy.server.search.school.api.dto.SchoolSearchResponse;
+import com.gloddy.server.search.school.manager.SchoolSearchManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.gloddy.server.search.school.api.dto.SchoolSearchResponse.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/search")
+public class SchoolSearchApi {
+
+    private final SchoolSearchManager schoolSearchManager;
+
+    @GetMapping("/schools")
+    public ResponseEntity<All> searchSchool(
+            @RequestParam(value = "keyword", required = false, defaultValue = "empty") String keyword
+    ) {
+        return ApiResponse.ok(schoolSearchManager.searchByNameKeyword(keyword));
+    }
+}

--- a/src/main/java/com/gloddy/server/search/school/api/dto/SchoolSearchResponse.java
+++ b/src/main/java/com/gloddy/server/search/school/api/dto/SchoolSearchResponse.java
@@ -1,0 +1,31 @@
+package com.gloddy.server.search.school.api.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class SchoolSearchResponse {
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class All {
+        private List<One> schools;
+    }
+
+    @NoArgsConstructor
+    @Getter
+    public static class One {
+        private String name;
+        private String address;
+
+        @QueryProjection
+        public One(String name, String address) {
+            this.name = name;
+            this.address = address;
+        }
+    }
+}

--- a/src/main/java/com/gloddy/server/search/school/infra/respository/SchoolJpaRepository.java
+++ b/src/main/java/com/gloddy/server/search/school/infra/respository/SchoolJpaRepository.java
@@ -1,0 +1,8 @@
+package com.gloddy.server.search.school.infra.respository;
+
+import com.gloddy.server.search.school.School;
+import com.gloddy.server.search.school.infra.respository.custom.SchoolJpaRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SchoolJpaRepository extends JpaRepository<School, Long>, SchoolJpaRepositoryCustom {
+}

--- a/src/main/java/com/gloddy/server/search/school/infra/respository/custom/SchoolJpaRepositoryCustom.java
+++ b/src/main/java/com/gloddy/server/search/school/infra/respository/custom/SchoolJpaRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.gloddy.server.search.school.infra.respository.custom;
+
+import com.gloddy.server.search.school.api.dto.SchoolSearchResponse;
+
+import java.util.List;
+
+public interface SchoolJpaRepositoryCustom {
+    List<SchoolSearchResponse.One> findByNameKeywordContain(String keyword);
+}

--- a/src/main/java/com/gloddy/server/search/school/infra/respository/impl/SchoolJpaRepositoryImpl.java
+++ b/src/main/java/com/gloddy/server/search/school/infra/respository/impl/SchoolJpaRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.gloddy.server.search.school.infra.respository.impl;
+
+
+import com.gloddy.server.search.school.api.dto.QSchoolSearchResponse_One;
+import com.gloddy.server.search.school.api.dto.SchoolSearchResponse;
+import com.gloddy.server.search.school.infra.respository.custom.SchoolJpaRepositoryCustom;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.gloddy.server.search.school.QSchool.*;
+import static org.apache.logging.log4j.util.Strings.isNotEmpty;
+
+@Repository
+@RequiredArgsConstructor
+public class SchoolJpaRepositoryImpl implements SchoolJpaRepositoryCustom {
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<SchoolSearchResponse.One> findByNameKeywordContain(String keyword) {
+        return query.select(new QSchoolSearchResponse_One(
+                        school.name,
+                        school.address))
+                .from(school)
+                .where(nameContains(keyword))
+                .fetch();
+
+    }
+
+    private BooleanExpression nameContains(String keyword) {
+        return isNotEmpty(keyword) ? school.name.containsIgnoreCase(keyword) : null;
+    }
+}

--- a/src/main/java/com/gloddy/server/search/school/manager/SchoolSearchManager.java
+++ b/src/main/java/com/gloddy/server/search/school/manager/SchoolSearchManager.java
@@ -1,0 +1,7 @@
+package com.gloddy.server.search.school.manager;
+
+import com.gloddy.server.search.school.api.dto.SchoolSearchResponse;
+
+public interface SchoolSearchManager {
+    SchoolSearchResponse.All searchByNameKeyword(String keyword);
+}

--- a/src/main/java/com/gloddy/server/search/school/manager/impl/SchoolSearchMysqlJpaManager.java
+++ b/src/main/java/com/gloddy/server/search/school/manager/impl/SchoolSearchMysqlJpaManager.java
@@ -1,0 +1,20 @@
+package com.gloddy.server.search.school.manager.impl;
+
+import com.gloddy.server.search.school.infra.respository.SchoolJpaRepository;
+import com.gloddy.server.search.school.manager.SchoolSearchManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.gloddy.server.search.school.api.dto.SchoolSearchResponse.*;
+
+@Component
+@RequiredArgsConstructor
+public class SchoolSearchMysqlJpaManager implements SchoolSearchManager {
+
+    private final SchoolJpaRepository schoolJpaRepository;
+
+    @Override
+    public All searchByNameKeyword(String keyword) {
+        return new All(schoolJpaRepository.findByNameKeywordContain(keyword));
+    }
+}


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #0
### 작업 사항
- 학교 검색 API를 구현하였습니다.
   - 학교 데이터 셋을 csv파일로 추출 후 mysql에 반영하였습니다.
   - 기존 JPA, Mysql을 이용하여 쿼리를 작성하였습니다.

**작업하면서 고민 및 선택(기술 스택 선택 및 성능)**
- 검색이다보니 전문 검색 Nosql(ex) ElasticSearch)를 쓸까 했는데 학교 데이터가 별로 되지 않고(443개) 배포 까지 시간이 얼마남지 않아 빠른 작업을 위해 기존 DB인 Mysql 계속 활용하였습니다.
- Mysql contain 검색을 위해 **like %s% (FullTableScan)** 말고 **FullText Index(Ngram)** 을 활용하고자 했으나 아래와 같이 성능 차이가 크게 안나서 그냥 like문을 활용하였습니다.
   - 성능 차이가 크게 안나는 이유는 아마 데이터가 많이 존재하지 않아서 인 듯 합니다.
   - 오히려 Ngram이 성능이 더 안좋게 측정될 때도 있었습니다.

### 성능비교 (like %s% vs Ngram)
- like %s% 활용 시 (FullTableScan)
![image](https://github.com/gloddy-dev/Gloddy-Server/assets/88091743/f3748bd6-d51a-4776-829c-f5af57713b8c)
Duration : 0.62925ms
- ngram 활용 시 (FullText Index)
![image](https://github.com/gloddy-dev/Gloddy-Server/assets/88091743/19b240f9-38b2-4aa4-81a5-07414508bfd1)
Duration: 0.46ms
