### PR TITLE
[FEAT]: 나의 모임 탭 조회 API 구현

### DIFF
--- a/src/main/java/com/gloddy/server/apply/api/ApplyApi.java
+++ b/src/main/java/com/gloddy/server/apply/api/ApplyApi.java
@@ -49,4 +49,14 @@ public class ApplyApi {
         ApplyResponse.GetAll response = applyService.getAll(userId, groupId);
         return ApiResponse.ok(response);
     }
+
+    @Operation(description = "거절된 지원서 확인")
+    @PostMapping("/applies/{applyId}")
+    public ResponseEntity<Void> checkRejectedApply(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable("applyId") Long applyId
+    ) {
+        applyService.checkRejectedApply(userId, applyId);
+        return ApiResponse.noContent();
+    }
 }

--- a/src/main/java/com/gloddy/server/apply/application/ApplyService.java
+++ b/src/main/java/com/gloddy/server/apply/application/ApplyService.java
@@ -8,6 +8,7 @@ import com.gloddy.server.apply.domain.handler.ApplyQueryHandler;
 import com.gloddy.server.apply.domain.service.ApplyDtoMapper;
 import com.gloddy.server.apply.domain.service.ApplyGetExecutor;
 import com.gloddy.server.apply.domain.service.ApplyStatusUpdatePolicy;
+import com.gloddy.server.apply.domain.service.RejectedApplyCheckExecutor;
 import com.gloddy.server.apply.domain.vo.Status;
 import com.gloddy.server.apply.event.producer.ApplyEventProducer;
 import com.gloddy.server.auth.domain.User;
@@ -33,6 +34,7 @@ public class ApplyService {
     private final GroupQueryHandler groupQueryHandler;
     private final ApplyStatusUpdatePolicy applyStatusUpdatePolicy;
     private final ApplyEventProducer applyEventProducer;
+    private final RejectedApplyCheckExecutor rejectedApplyCheckExecutor;
 
     @Transactional
     public ApplyResponse.Create createApply(Long userId, Long groupId, ApplyRequest.Create request) {
@@ -61,5 +63,10 @@ public class ApplyService {
     public ApplyResponse.GetAll getAll(Long userId, Long groupId) {
         List<Apply> applies = applyGetExecutor.getAllWaitApply(userId, groupId);
         return ApplyDtoMapper.mapToGetAll(applies);
+    }
+
+    @Transactional
+    public void checkRejectedApply(Long userId, Long applyId) {
+        rejectedApplyCheckExecutor.check(userId, applyId);
     }
 }

--- a/src/main/java/com/gloddy/server/apply/domain/Apply.java
+++ b/src/main/java/com/gloddy/server/apply/domain/Apply.java
@@ -12,6 +12,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 
 @Entity
 @NoArgsConstructor
@@ -42,6 +44,9 @@ public class Apply extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Status status;
 
+    @Column(name = "is_check_rejected")
+    private boolean isCheckRejected;
+
     @Builder
     public Apply(User user, Group group, String content, String reason) {
         this.user = user;
@@ -49,6 +54,7 @@ public class Apply extends BaseTimeEntity {
         this.content = content;
         this.reason = reason;
         this.status = Status.WAIT;
+        this.isCheckRejected = false;
     }
 
     public void approveApply(ApplyEventProducer applyEventProducer) {
@@ -62,5 +68,13 @@ public class Apply extends BaseTimeEntity {
 
     public boolean isApproved() {
         return this.status.isApprove();
+    }
+
+    public void checkRejected() {
+        if (this.status.equals(Status.REFUSE)) {
+            this.isCheckRejected = true;
+        } else {
+            throw new RuntimeException("cant check Rejected");
+        }
     }
 }

--- a/src/main/java/com/gloddy/server/apply/domain/dto/ApplyResponse.java
+++ b/src/main/java/com/gloddy/server/apply/domain/dto/ApplyResponse.java
@@ -34,9 +34,11 @@ public class ApplyResponse {
     @Schema(name = "ApplyGetOneResponse")
     public static class GetOne {
         private Long userId;
+        private Boolean isCertifiedStudent;
         private String userNickname;
         private String userImageUrl;
         private ReliabilityLevel reliabilityLevel;
+        private Long applyId;
         private String introduce;
         private String reason;
     }

--- a/src/main/java/com/gloddy/server/apply/domain/handler/ApplyQueryHandler.java
+++ b/src/main/java/com/gloddy/server/apply/domain/handler/ApplyQueryHandler.java
@@ -16,4 +16,6 @@ public interface ApplyQueryHandler {
     Apply findApplyToUpdateStatus(Long id);
 
     List<Apply> findAllByGroupIdAndStatus(Long groupId, Status status);
+
+    Long countAppliesByGroupIdAndStatus(Long groupId, Status status);
 }

--- a/src/main/java/com/gloddy/server/apply/domain/handler/ApplyQueryHandler.java
+++ b/src/main/java/com/gloddy/server/apply/domain/handler/ApplyQueryHandler.java
@@ -18,4 +18,6 @@ public interface ApplyQueryHandler {
     List<Apply> findAllByGroupIdAndStatus(Long groupId, Status status);
 
     Long countAppliesByGroupIdAndStatus(Long groupId, Status status);
+
+    List<Apply> findAllByUserIdAndStatus(Long userId, Status status);
 }

--- a/src/main/java/com/gloddy/server/apply/domain/handler/ApplyQueryHandler.java
+++ b/src/main/java/com/gloddy/server/apply/domain/handler/ApplyQueryHandler.java
@@ -20,4 +20,6 @@ public interface ApplyQueryHandler {
     Long countAppliesByGroupIdAndStatus(Long groupId, Status status);
 
     List<Apply> findAllByUserIdAndStatus(Long userId, Status status);
+
+    Apply findById(Long applyId);
 }

--- a/src/main/java/com/gloddy/server/apply/domain/handler/impl/ApplyQueryHandlerImpl.java
+++ b/src/main/java/com/gloddy/server/apply/domain/handler/impl/ApplyQueryHandlerImpl.java
@@ -37,4 +37,9 @@ public class ApplyQueryHandlerImpl implements ApplyQueryHandler {
     public List<Apply> findAllByGroupIdAndStatus(Long groupId, Status status) {
         return applyJpaRepository.findAllByGroupIdAndStatus(groupId, status);
     }
+
+    @Override
+    public Long countAppliesByGroupIdAndStatus(Long groupId, Status status) {
+        return applyJpaRepository.countByGroupIdAndStatus(groupId, status);
+    }
 }

--- a/src/main/java/com/gloddy/server/apply/domain/handler/impl/ApplyQueryHandlerImpl.java
+++ b/src/main/java/com/gloddy/server/apply/domain/handler/impl/ApplyQueryHandlerImpl.java
@@ -42,4 +42,9 @@ public class ApplyQueryHandlerImpl implements ApplyQueryHandler {
     public Long countAppliesByGroupIdAndStatus(Long groupId, Status status) {
         return applyJpaRepository.countByGroupIdAndStatus(groupId, status);
     }
+
+    @Override
+    public List<Apply> findAllByUserIdAndStatus(Long userId, Status status) {
+        return applyJpaRepository.findAllByUserIdAndStatus(userId, status);
+    }
 }

--- a/src/main/java/com/gloddy/server/apply/domain/handler/impl/ApplyQueryHandlerImpl.java
+++ b/src/main/java/com/gloddy/server/apply/domain/handler/impl/ApplyQueryHandlerImpl.java
@@ -47,4 +47,10 @@ public class ApplyQueryHandlerImpl implements ApplyQueryHandler {
     public List<Apply> findAllByUserIdAndStatus(Long userId, Status status) {
         return applyJpaRepository.findAllByUserIdAndStatus(userId, status);
     }
+
+    @Override
+    public Apply findById(Long applyId) {
+        return applyJpaRepository.findByIdFetchUserAndGroup(applyId)
+                .orElseThrow(NotFoundApplyException::new);
+    }
 }

--- a/src/main/java/com/gloddy/server/apply/domain/service/ApplyDtoMapper.java
+++ b/src/main/java/com/gloddy/server/apply/domain/service/ApplyDtoMapper.java
@@ -21,12 +21,13 @@ public class ApplyDtoMapper {
         User applyUser = apply.getUser();
         return new ApplyResponse.GetOne(
                 applyUser.getId(),
+                applyUser.isCertifiedStudent(),
                 applyUser.getNickName(),
                 applyUser.getImageUrl(),
                 applyUser.getReliabilityLevel(),
+                apply.getId(),
                 apply.getContent(),
                 apply.getReason()
         );
     }
-
 }

--- a/src/main/java/com/gloddy/server/apply/domain/service/RejectedApplyCheckExecutor.java
+++ b/src/main/java/com/gloddy/server/apply/domain/service/RejectedApplyCheckExecutor.java
@@ -1,0 +1,26 @@
+package com.gloddy.server.apply.domain.service;
+
+import com.gloddy.server.apply.domain.Apply;
+import com.gloddy.server.apply.domain.handler.ApplyQueryHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RejectedApplyCheckExecutor {
+
+    private final ApplyQueryHandler applyQueryHandler;
+
+    public void check(Long userId, Long applyId) {
+        Apply apply = applyQueryHandler.findById(applyId);
+
+        validate(apply, userId);
+        apply.checkRejected();
+    }
+
+    private void validate(Apply apply, Long userId) {
+        if (!apply.getUser().getId().equals(userId)) {
+            throw new RuntimeException("no authorize rejected apply check");
+        }
+    }
+}

--- a/src/main/java/com/gloddy/server/apply/infra/repository/custom/ApplyJpaRepositoryCustom.java
+++ b/src/main/java/com/gloddy/server/apply/infra/repository/custom/ApplyJpaRepositoryCustom.java
@@ -11,4 +11,6 @@ public interface ApplyJpaRepositoryCustom {
     Optional<Apply> findByIdFetchGroupAndCaptain(Long id);
 
     List<Apply> findAllByGroupIdAndStatus(Long groupId, Status status);
+
+    List<Apply> findAllByUserIdAndStatus(Long userId, Status status);
 }

--- a/src/main/java/com/gloddy/server/apply/infra/repository/custom/ApplyJpaRepositoryCustom.java
+++ b/src/main/java/com/gloddy/server/apply/infra/repository/custom/ApplyJpaRepositoryCustom.java
@@ -13,4 +13,6 @@ public interface ApplyJpaRepositoryCustom {
     List<Apply> findAllByGroupIdAndStatus(Long groupId, Status status);
 
     List<Apply> findAllByUserIdAndStatus(Long userId, Status status);
+
+    Optional<Apply> findByIdFetchUserAndGroup(Long id);
 }

--- a/src/main/java/com/gloddy/server/apply/infra/repository/impl/ApplyJpaRepositoryImpl.java
+++ b/src/main/java/com/gloddy/server/apply/infra/repository/impl/ApplyJpaRepositoryImpl.java
@@ -45,6 +45,15 @@ public class ApplyJpaRepositoryImpl implements ApplyJpaRepositoryCustom {
                 .fetch();
     }
 
+    @Override
+    public List<Apply> findAllByUserIdAndStatus(Long userId, Status status) {
+        return query.selectFrom(apply)
+                .join(apply.user, user).fetchJoin()
+                .join(apply.group, group).fetchJoin()
+                .where(userIdEq(userId), statusEq(status))
+                .fetch();
+    }
+
     private BooleanExpression idEq(Long id) {
         return apply.id.eq(id);
     }
@@ -55,5 +64,9 @@ public class ApplyJpaRepositoryImpl implements ApplyJpaRepositoryCustom {
 
     private BooleanExpression statusEq(Status status) {
         return apply.status.eq(status);
+    }
+
+    private BooleanExpression userIdEq(Long userId) {
+        return apply.user.id.eq(userId);
     }
 }

--- a/src/main/java/com/gloddy/server/apply/infra/repository/impl/ApplyJpaRepositoryImpl.java
+++ b/src/main/java/com/gloddy/server/apply/infra/repository/impl/ApplyJpaRepositoryImpl.java
@@ -54,6 +54,17 @@ public class ApplyJpaRepositoryImpl implements ApplyJpaRepositoryCustom {
                 .fetch();
     }
 
+    @Override
+    public Optional<Apply> findByIdFetchUserAndGroup(Long id) {
+        Apply apply = query.selectFrom(QApply.apply)
+                .join(QApply.apply.group, group).fetchJoin()
+                .join(QApply.apply.user, user).fetchJoin()
+                .where(idEq(id))
+                .fetchOne();
+
+        return Optional.ofNullable(apply);
+    }
+
     private BooleanExpression idEq(Long id) {
         return apply.id.eq(id);
     }

--- a/src/main/java/com/gloddy/server/group/domain/Group.java
+++ b/src/main/java/com/gloddy/server/group/domain/Group.java
@@ -109,4 +109,8 @@ public class Group extends BaseTimeEntity {
     public boolean isCaptain(User user) {
         return this.captain.equals(user);
     }
+
+    public boolean isEndGroup() {
+        return this.getEndDateTime().isBefore(LocalDateTime.now());
+    }
 }

--- a/src/main/java/com/gloddy/server/group/domain/Group.java
+++ b/src/main/java/com/gloddy/server/group/domain/Group.java
@@ -32,7 +32,7 @@ public class Group extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "captain_id")
     private User captain;
 

--- a/src/main/java/com/gloddy/server/group/domain/dto/GroupRequest.java
+++ b/src/main/java/com/gloddy/server/group/domain/dto/GroupRequest.java
@@ -24,8 +24,8 @@ public class GroupRequest {
         private String endTime;
         private String placeName;
         private String placeAddress;
-        private String place_latitude;
-        private String place_longitude;
+        private String placeLatitude;
+        private String placeLongitude;
         private int maxUser;
     }
 

--- a/src/main/java/com/gloddy/server/group/domain/dto/GroupResponse.java
+++ b/src/main/java/com/gloddy/server/group/domain/dto/GroupResponse.java
@@ -37,9 +37,12 @@ public class GroupResponse {
         private String title;
         private String content;
         private int memberCount;
-        private int maxUser;
-        private String place;
+        private int maxMemberCount;
+        private String placeName;
+        private String placeAddress;
         private String meetDate;
+        private String startTime;
+        private String endTime;
 
         public static GetGroup from(Group group) {
             return new GetGroup(
@@ -49,8 +52,11 @@ public class GroupResponse {
                     group.getContent(),
                     group.getMemberCount(),
                     group.getMaxUser(),
+                    group.getPlace().getName(),
                     group.getPlace().getAddress(),
-                    dateToStringForGroupPreview(group.getStartDateTime())
+                    group.getMeetDate().toString(),
+                    group.getStartDateTime().toLocalTime().toString(),
+                    group.getEndDateTime().toLocalTime().toString()
             );
         }
     }
@@ -61,6 +67,7 @@ public class GroupResponse {
     public static class GetGroupDetail {
         private Boolean myGroup;
         private Boolean isCaptain;
+        private Long groupId;
         private String title;
         private String fileUrl;
         private String content;
@@ -71,8 +78,8 @@ public class GroupResponse {
         private String endTime;
         private String placeName;
         private String placeAddress;
-        private String place_latitude;
-        private String place_longitude;
+        private String placeLatitude;
+        private String placeLongitude;
     }
 
     @Getter

--- a/src/main/java/com/gloddy/server/group/domain/dto/GroupResponse.java
+++ b/src/main/java/com/gloddy/server/group/domain/dto/GroupResponse.java
@@ -104,7 +104,7 @@ public class GroupResponse {
                     groupMember.getGroup().getMemberCount(),
                     groupMember.getGroup().getPlace().getName(),
                     groupMember.getGroup().getMeetDate(),
-                    groupMember.isPraised()
+                    groupMember.isEndEstimate()
             );
         }
     }

--- a/src/main/java/com/gloddy/server/group/domain/handler/GroupQueryHandler.java
+++ b/src/main/java/com/gloddy/server/group/domain/handler/GroupQueryHandler.java
@@ -4,9 +4,13 @@ import com.gloddy.server.group.domain.Group;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface GroupQueryHandler {
 
     Group findById(Long id);
 
     Page<Group> findGroupPage(Pageable pageable);
+
+    List<Group> findAllByCaptainId(Long captainId);
 }

--- a/src/main/java/com/gloddy/server/group/domain/handler/impl/GroupQueryHandlerImpl.java
+++ b/src/main/java/com/gloddy/server/group/domain/handler/impl/GroupQueryHandlerImpl.java
@@ -9,6 +9,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 import static com.gloddy.server.core.error.handler.errorCode.ErrorCode.*;
 
 @Repository
@@ -27,5 +29,10 @@ public class GroupQueryHandlerImpl implements GroupQueryHandler {
     @Override
     public Page<Group> findGroupPage(Pageable pageable) {
         return groupJpaRepository.findAllByOrderByIdDesc(pageable);
+    }
+
+    @Override
+    public List<Group> findAllByCaptainId(Long captainId) {
+        return groupJpaRepository.findAllByCaptainId(captainId);
     }
 }

--- a/src/main/java/com/gloddy/server/group/domain/service/GroupDtoMapper.java
+++ b/src/main/java/com/gloddy/server/group/domain/service/GroupDtoMapper.java
@@ -16,6 +16,7 @@ public class GroupDtoMapper {
         return new GetGroupDetail(
                 groupChecker.isMyGroup(user, group),
                 groupChecker.isGroupCaptain(user, group),
+                group.getId(),
                 group.getTitle(),
                 group.getImageUrl(),
                 group.getContent(),

--- a/src/main/java/com/gloddy/server/group/domain/service/GroupFactory.java
+++ b/src/main/java/com/gloddy/server/group/domain/service/GroupFactory.java
@@ -23,8 +23,8 @@ public class GroupFactory {
         GroupPlace place = getGroupPlace(
                 request.getPlaceName(),
                 request.getPlaceAddress(),
-                request.getPlace_latitude(),
-                request.getPlace_longitude()
+                request.getPlaceLatitude(),
+                request.getPlaceLongitude()
         );
 
         return Group.builder()

--- a/src/main/java/com/gloddy/server/group/infra/repository/custom/GroupJpaRepositoryCustom.java
+++ b/src/main/java/com/gloddy/server/group/infra/repository/custom/GroupJpaRepositoryCustom.java
@@ -1,4 +1,10 @@
 package com.gloddy.server.group.infra.repository.custom;
 
+import com.gloddy.server.group.domain.Group;
+
+import java.util.List;
+
 public interface GroupJpaRepositoryCustom {
+
+    List<Group> findAllByCaptainId(Long captainId);
 }

--- a/src/main/java/com/gloddy/server/group/infra/repository/impl/GroupJpaRepositoryImpl.java
+++ b/src/main/java/com/gloddy/server/group/infra/repository/impl/GroupJpaRepositoryImpl.java
@@ -1,13 +1,36 @@
 package com.gloddy.server.group.infra.repository.impl;
 
+import com.gloddy.server.auth.domain.QUser;
+import com.gloddy.server.group.domain.Group;
+import com.gloddy.server.group.domain.QGroup;
 import com.gloddy.server.group.infra.repository.custom.GroupJpaRepositoryCustom;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.gloddy.server.auth.domain.QUser.*;
+import static com.gloddy.server.group.domain.QGroup.*;
 
 @Repository
 @RequiredArgsConstructor
 public class GroupJpaRepositoryImpl implements GroupJpaRepositoryCustom {
 
     private final JPAQueryFactory query;
+
+
+    @Override
+    public List<Group> findAllByCaptainId(Long captainId) {
+        return query.selectFrom(group)
+                .join(group.captain, user).fetchJoin()
+                .where(captainIdEq(captainId))
+                .fetch();
+
+    }
+
+    private BooleanExpression captainIdEq(Long captainId) {
+        return group.captain.id.eq(captainId);
+    }
 }

--- a/src/main/java/com/gloddy/server/group_member/application/GroupMemberService.java
+++ b/src/main/java/com/gloddy/server/group_member/application/GroupMemberService.java
@@ -49,6 +49,7 @@ public class GroupMemberService {
         );
     }
 
+    @Transactional
     public void estimateGroupMembers(GroupMemberRequest.Estimate request, Long userId, Long groupId) {
         GroupMember estimator = groupMemberQueryHandler.findByUserIdAndGroupId(userId, groupId);
         estimator.estimateGroupMembers(request, groupMemberPraisePolicy, groupMemberPraiser, groupMemberEventProducer);

--- a/src/main/java/com/gloddy/server/group_member/domain/GroupMember.java
+++ b/src/main/java/com/gloddy/server/group_member/domain/GroupMember.java
@@ -2,6 +2,7 @@ package com.gloddy.server.group_member.domain;
 
 import com.gloddy.server.article.domain.Article;
 import com.gloddy.server.auth.domain.User;
+import com.gloddy.server.core.entity.common.BaseTimeEntity;
 import com.gloddy.server.group_member.event.GroupMemberEstimateCompleteEvent;
 import com.gloddy.server.group_member.event.GroupMemberSelectBestMateEvent;
 import com.gloddy.server.group_member.domain.dto.GroupMemberRequest;
@@ -23,8 +24,8 @@ import static com.gloddy.server.group_member.domain.dto.GroupMemberRequest.Estim
 @Entity
 @Getter
 @Table(name = "group_member")
-@EqualsAndHashCode(of = {"id"})
-public class GroupMember {
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
+public class GroupMember extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gloddy/server/group_member/domain/GroupMember.java
+++ b/src/main/java/com/gloddy/server/group_member/domain/GroupMember.java
@@ -49,8 +49,8 @@ public class GroupMember extends BaseTimeEntity {
     @Column(name = "is_end")
     private boolean isEnd;
 
-    @Column(name = "is_praised")
-    private boolean isPraised;
+    @Column(name = "is_end_estimate")
+    private boolean isEndEstimate;
 
     public static GroupMember empty() {
         return new GroupMember();
@@ -60,7 +60,7 @@ public class GroupMember extends BaseTimeEntity {
         this.user = user;
         this.group = group;
         this.isEnd = false;
-        this.isPraised = false;
+        this.isEndEstimate = false;
         this.absenceVoteCount = 0;
         this.isAbsence = false;
     }
@@ -73,6 +73,7 @@ public class GroupMember extends BaseTimeEntity {
                                      GroupMemberPraiser groupMemberPraiser, GroupMemberEventProducer groupMemberEventProducer) {
         praiseGroupMembers(estimateInfo.getPraiseInfos(), groupMemberPraisePolicy, groupMemberPraiser);
         selectBestMate(estimateInfo.getMateInfo(), groupMemberEventProducer);
+        completeEstimate();
         groupMemberEventProducer.produceEvent(new GroupMemberEstimateCompleteEvent(this.getUser().getId()));
     }
 
@@ -86,8 +87,8 @@ public class GroupMember extends BaseTimeEntity {
         groupMemberEventProducer.produceEvent(new GroupMemberSelectBestMateEvent(mateInfo, this.user.getId()));
     }
 
-    public void completePraise() {
-        this.isPraised = true;
+    public void completeEstimate() {
+        this.isEndEstimate = true;
     }
 
     public void plusAbsenceVoteCount() {

--- a/src/main/java/com/gloddy/server/group_member/domain/GroupMember.java
+++ b/src/main/java/com/gloddy/server/group_member/domain/GroupMember.java
@@ -15,6 +15,7 @@ import lombok.*;
 
 import jakarta.persistence.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.gloddy.server.group_member.domain.dto.GroupMemberRequest.Estimate.*;
@@ -120,5 +121,9 @@ public class GroupMember extends BaseTimeEntity {
 
     public boolean isCaptain() {
         return this.user.equals(this.getGroup().getCaptain());
+    }
+
+    public boolean isNewGroupMember() {
+        return this.getCreatedAt().isAfter(LocalDateTime.now().minusHours(1));
     }
 }

--- a/src/main/java/com/gloddy/server/group_member/domain/handler/GroupMemberQueryHandler.java
+++ b/src/main/java/com/gloddy/server/group_member/domain/handler/GroupMemberQueryHandler.java
@@ -10,4 +10,6 @@ public interface GroupMemberQueryHandler {
     List<GroupMember> findAllByGroupId(Long groupId);
 
     List<GroupMember> findAllByUserIdInAndGroupId(List<Long> userIds, Long groupId);
+
+    List<GroupMember> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/gloddy/server/group_member/domain/handler/impl/GroupMemberQueryHandlerImpl.java
+++ b/src/main/java/com/gloddy/server/group_member/domain/handler/impl/GroupMemberQueryHandlerImpl.java
@@ -29,4 +29,9 @@ public class GroupMemberQueryHandlerImpl implements GroupMemberQueryHandler {
     public List<GroupMember> findAllByUserIdInAndGroupId(List<Long> userIds, Long groupId) {
         return groupMemberJpaRepository.findByUserIdInAndGroupId(userIds, groupId);
     }
+
+    @Override
+    public List<GroupMember> findAllByUserId(Long userId) {
+        return groupMemberJpaRepository.findByUserIdFetchGroupAndUser(userId);
+    }
 }

--- a/src/main/java/com/gloddy/server/group_member/infra/repository/custom/GroupMemberJpaRepositoryCustom.java
+++ b/src/main/java/com/gloddy/server/group_member/infra/repository/custom/GroupMemberJpaRepositoryCustom.java
@@ -17,4 +17,6 @@ public interface GroupMemberJpaRepositoryCustom {
     List<GroupMember> findUserGroupsToPraiseByUserIdInAndGroupId(List<Long> userIds, Long groupId);
 
     List<GroupMember> findAllByGroupIdFetchUserAndGroup(Long groupId);
+
+    List<GroupMember> findByUserIdFetchGroupAndUser(Long userId);
 }

--- a/src/main/java/com/gloddy/server/group_member/infra/repository/impl/GroupMemberJpaRepositoryImpl.java
+++ b/src/main/java/com/gloddy/server/group_member/infra/repository/impl/GroupMemberJpaRepositoryImpl.java
@@ -78,6 +78,16 @@ public class GroupMemberJpaRepositoryImpl implements GroupMemberJpaRepositoryCus
                 .fetch();
     }
 
+    @Override
+    public List<GroupMember> findByUserIdFetchGroupAndUser(Long userId) {
+        return query.select(groupMember)
+                .from(groupMember)
+                .join(groupMember.group, group).fetchJoin()
+                .join(groupMember.user, user).fetchJoin()
+                .where(userIdEq(userId))
+                .fetch();
+    }
+
     private BooleanExpression userEq(User user) {
         return groupMember.user.eq(user);
     }
@@ -96,5 +106,9 @@ public class GroupMemberJpaRepositoryImpl implements GroupMemberJpaRepositoryCus
 
     private BooleanExpression groupIdEq(Long groupId) {
         return groupMember.group.id.eq(groupId);
+    }
+
+    private BooleanExpression userIdEq(Long userId) {
+        return groupMember.user.id.eq(userId);
     }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadController.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadController.java
@@ -23,8 +23,9 @@ public class MyGroupReadController {
     }
 
     @GetMapping("/users/groups/hosting")
-    public void getHostingGroups(@AuthenticationPrincipal Long userId) {
-
+    public ResponseEntity<MyGroupResponse.Hosting> getHostingGroups(@AuthenticationPrincipal Long userId) {
+        MyGroupResponse.Hosting response = myGroupReadService.getHostingGroups(userId);
+        return ApiResponse.ok(response);
     }
 
     @GetMapping("/users/groups/waiting")

--- a/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadController.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadController.java
@@ -35,7 +35,8 @@ public class MyGroupReadController {
     }
 
     @GetMapping("/users/groups/rejected")
-    public void getRejectedGroups(@AuthenticationPrincipal Long userId) {
-
+    public ResponseEntity<MyGroupResponse.Rejected> getRejectedGroups(@AuthenticationPrincipal Long userId) {
+        MyGroupResponse.Rejected response = myGroupReadService.getRejectedGroups(userId);
+        return ApiResponse.ok(response);
     }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadController.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadController.java
@@ -29,8 +29,9 @@ public class MyGroupReadController {
     }
 
     @GetMapping("/users/groups/waiting")
-    public void getWaitingGroups(@AuthenticationPrincipal Long userId) {
-
+    public ResponseEntity<MyGroupResponse.Waiting> getWaitingGroups(@AuthenticationPrincipal Long userId) {
+        MyGroupResponse.Waiting response = myGroupReadService.getWaitingGroups(userId);
+        return ApiResponse.ok(response);
     }
 
     @GetMapping("/users/groups/rejected")

--- a/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadController.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadController.java
@@ -39,4 +39,10 @@ public class MyGroupReadController {
         MyGroupResponse.Rejected response = myGroupReadService.getRejectedGroups(userId);
         return ApiResponse.ok(response);
     }
+
+    @GetMapping("/users/groups/notEstimated")
+    public ResponseEntity<MyGroupResponse.NotEstimated> getNotEstimatedGroups(@AuthenticationPrincipal Long userId) {
+        MyGroupResponse.NotEstimated response = myGroupReadService.getNotEstimatedGroups(userId);
+        return ApiResponse.ok(response);
+    }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadController.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadController.java
@@ -1,0 +1,39 @@
+package com.gloddy.server.myGroup.read;
+
+import com.gloddy.server.core.response.ApiResponse;
+import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class MyGroupReadController {
+
+    private final MyGroupReadService myGroupReadService;
+
+    @GetMapping("/users/groups/participating")
+    public ResponseEntity<MyGroupResponse.Participating> getParticipatingGroups(@AuthenticationPrincipal Long userId) {
+        MyGroupResponse.Participating response = myGroupReadService.getParticipatingGroups(userId);
+        return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/users/groups/hosting")
+    public void getHostingGroups(@AuthenticationPrincipal Long userId) {
+
+    }
+
+    @GetMapping("/users/groups/waiting")
+    public void getWaitingGroups(@AuthenticationPrincipal Long userId) {
+
+    }
+
+    @GetMapping("/users/groups/rejected")
+    public void getRejectedGroups(@AuthenticationPrincipal Long userId) {
+
+    }
+}

--- a/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadService.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadService.java
@@ -1,13 +1,19 @@
 package com.gloddy.server.myGroup.read;
 
+import com.gloddy.server.group.domain.Group;
+import com.gloddy.server.myGroup.read.domainService.NotEstimatedGroupGetExecutor;
 import com.gloddy.server.myGroup.read.domainService.ParticipatingGroupGetExecutor;
 import com.gloddy.server.myGroup.read.domainService.RejectedGroupGetExecutor;
 import com.gloddy.server.myGroup.read.domainService.WaitingGroupGetExecutor;
 import com.gloddy.server.myGroup.read.domainService.facade.HostingGroupGetFacade;
 import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
+import com.gloddy.server.myGroup.read.util.MyGroupDtoMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +23,7 @@ public class MyGroupReadService {
     private final HostingGroupGetFacade hostingGroupGetFacade;
     private final WaitingGroupGetExecutor waitingGroupGetExecutor;
     private final RejectedGroupGetExecutor rejectedGroupGetExecutor;
+    private final NotEstimatedGroupGetExecutor notEstimatedGroupGetExecutor;
 
     @Transactional(readOnly = true)
     public MyGroupResponse.Participating getParticipatingGroups(Long userId) {
@@ -36,5 +43,13 @@ public class MyGroupReadService {
     @Transactional(readOnly = true)
     public MyGroupResponse.Rejected getRejectedGroups(Long userId) {
         return rejectedGroupGetExecutor.getRejectedGroups(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public MyGroupResponse.NotEstimated getNotEstimatedGroups(Long userId) {
+        List<Group> groups = notEstimatedGroupGetExecutor.getNotEstimatedGroups(userId);
+        return groups.stream()
+                .map(it -> MyGroupDtoMapper.mapToNotEstimatedOne(userId, it))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), MyGroupResponse.NotEstimated::new));
     }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadService.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadService.java
@@ -1,6 +1,7 @@
 package com.gloddy.server.myGroup.read;
 
 import com.gloddy.server.myGroup.read.domainService.ParticipatingGroupGetExecutor;
+import com.gloddy.server.myGroup.read.domainService.WaitingGroupGetExecutor;
 import com.gloddy.server.myGroup.read.domainService.facade.HostingGroupGetFacade;
 import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ public class MyGroupReadService {
 
     private final ParticipatingGroupGetExecutor participatingGroupGetExecutor;
     private final HostingGroupGetFacade hostingGroupGetFacade;
+    private final WaitingGroupGetExecutor waitingGroupGetExecutor;
 
     @Transactional(readOnly = true)
     public MyGroupResponse.Participating getParticipatingGroups(Long userId) {
@@ -22,5 +24,10 @@ public class MyGroupReadService {
     @Transactional(readOnly = true)
     public MyGroupResponse.Hosting getHostingGroups(Long userId) {
         return hostingGroupGetFacade.getHostingGroups(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public MyGroupResponse.Waiting getWaitingGroups(Long userId) {
+        return waitingGroupGetExecutor.getWaitingGroups(userId);
     }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadService.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadService.java
@@ -1,6 +1,7 @@
 package com.gloddy.server.myGroup.read;
 
 import com.gloddy.server.myGroup.read.domainService.ParticipatingGroupGetExecutor;
+import com.gloddy.server.myGroup.read.domainService.RejectedGroupGetExecutor;
 import com.gloddy.server.myGroup.read.domainService.WaitingGroupGetExecutor;
 import com.gloddy.server.myGroup.read.domainService.facade.HostingGroupGetFacade;
 import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
@@ -15,6 +16,7 @@ public class MyGroupReadService {
     private final ParticipatingGroupGetExecutor participatingGroupGetExecutor;
     private final HostingGroupGetFacade hostingGroupGetFacade;
     private final WaitingGroupGetExecutor waitingGroupGetExecutor;
+    private final RejectedGroupGetExecutor rejectedGroupGetExecutor;
 
     @Transactional(readOnly = true)
     public MyGroupResponse.Participating getParticipatingGroups(Long userId) {
@@ -29,5 +31,10 @@ public class MyGroupReadService {
     @Transactional(readOnly = true)
     public MyGroupResponse.Waiting getWaitingGroups(Long userId) {
         return waitingGroupGetExecutor.getWaitingGroups(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public MyGroupResponse.Rejected getRejectedGroups(Long userId) {
+        return rejectedGroupGetExecutor.getRejectedGroups(userId);
     }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadService.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadService.java
@@ -1,0 +1,19 @@
+package com.gloddy.server.myGroup.read;
+
+import com.gloddy.server.myGroup.read.domainService.ParticipatingGroupGetExecutor;
+import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MyGroupReadService {
+
+    private final ParticipatingGroupGetExecutor participatingGroupGetExecutor;
+
+    @Transactional(readOnly = true)
+    public MyGroupResponse.Participating getParticipatingGroups(Long userId) {
+        return participatingGroupGetExecutor.getParticipatingGroups(userId);
+    }
+}

--- a/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadService.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/MyGroupReadService.java
@@ -1,6 +1,7 @@
 package com.gloddy.server.myGroup.read;
 
 import com.gloddy.server.myGroup.read.domainService.ParticipatingGroupGetExecutor;
+import com.gloddy.server.myGroup.read.domainService.facade.HostingGroupGetFacade;
 import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,9 +12,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class MyGroupReadService {
 
     private final ParticipatingGroupGetExecutor participatingGroupGetExecutor;
+    private final HostingGroupGetFacade hostingGroupGetFacade;
 
     @Transactional(readOnly = true)
     public MyGroupResponse.Participating getParticipatingGroups(Long userId) {
         return participatingGroupGetExecutor.getParticipatingGroups(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public MyGroupResponse.Hosting getHostingGroups(Long userId) {
+        return hostingGroupGetFacade.getHostingGroups(userId);
     }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/domainService/HostingGroupExistNewApplyChecker.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/domainService/HostingGroupExistNewApplyChecker.java
@@ -1,0 +1,18 @@
+package com.gloddy.server.myGroup.read.domainService;
+
+import com.gloddy.server.apply.domain.handler.ApplyQueryHandler;
+import com.gloddy.server.apply.domain.vo.Status;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HostingGroupExistNewApplyChecker {
+
+    private final ApplyQueryHandler applyQueryHandler;
+
+    public boolean isExistNewApply(Long groupId) {
+        Long countNewApplies = applyQueryHandler.countAppliesByGroupIdAndStatus(groupId, Status.WAIT);
+        return countNewApplies > 0;
+    }
+}

--- a/src/main/java/com/gloddy/server/myGroup/read/domainService/HostingGroupGetExecutor.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/domainService/HostingGroupGetExecutor.java
@@ -1,0 +1,34 @@
+package com.gloddy.server.myGroup.read.domainService;
+
+import com.gloddy.server.group.domain.Group;
+import com.gloddy.server.group.domain.handler.GroupQueryHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class HostingGroupGetExecutor {
+
+    private final GroupQueryHandler groupQueryHandler;
+
+    public List<Group> getHostingGroups(Long userId) {
+        List<Group> groups = groupQueryHandler.findAllByCaptainId(userId);
+
+        return groups.stream()
+                .filter(this::isNotEndGroup)
+                .sorted(Comparator.comparing(this::getGroupCreatedAt).reversed())
+                .toList();
+    }
+
+    private boolean isNotEndGroup(Group group) {
+        return group.getDateTime().getStartDateTime().isAfter(LocalDateTime.now());
+    }
+
+    private LocalDateTime getGroupCreatedAt(Group group) {
+        return group.getCreatedAt();
+    }
+}

--- a/src/main/java/com/gloddy/server/myGroup/read/domainService/HostingGroupGetExecutor.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/domainService/HostingGroupGetExecutor.java
@@ -5,9 +5,10 @@ import com.gloddy.server.group.domain.handler.GroupQueryHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+
+import static java.util.Comparator.*;
 
 @Component
 @RequiredArgsConstructor
@@ -20,15 +21,15 @@ public class HostingGroupGetExecutor {
 
         return groups.stream()
                 .filter(this::isNotEndGroup)
-                .sorted(Comparator.comparing(this::getGroupCreatedAt).reversed())
+                .sorted(groupCreatedAtDesc())
                 .toList();
     }
 
     private boolean isNotEndGroup(Group group) {
-        return group.getDateTime().getStartDateTime().isAfter(LocalDateTime.now());
+        return !group.isEndGroup();
     }
 
-    private LocalDateTime getGroupCreatedAt(Group group) {
-        return group.getCreatedAt();
+    private Comparator<? super Group> groupCreatedAtDesc() {
+        return comparing(Group::getCreatedAt).reversed();
     }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/domainService/NotEstimatedGroupGetExecutor.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/domainService/NotEstimatedGroupGetExecutor.java
@@ -30,6 +30,6 @@ public class NotEstimatedGroupGetExecutor {
     }
 
     private boolean isEndGroup(Group group) {
-        return group.getStartDateTime().isBefore(LocalDateTime.now());
+        return group.isEndGroup();
     }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/domainService/NotEstimatedGroupGetExecutor.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/domainService/NotEstimatedGroupGetExecutor.java
@@ -1,0 +1,35 @@
+package com.gloddy.server.myGroup.read.domainService;
+
+import com.gloddy.server.group.domain.Group;
+import com.gloddy.server.group_member.domain.GroupMember;
+import com.gloddy.server.group_member.domain.handler.GroupMemberQueryHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NotEstimatedGroupGetExecutor {
+
+    private final GroupMemberQueryHandler groupMemberQueryHandler;
+
+    public List<Group> getNotEstimatedGroups(Long userId) {
+        List<GroupMember> groupMembers = groupMemberQueryHandler.findAllByUserId(userId);
+
+        return groupMembers.stream()
+                .filter(this::isNotEndEstimate)
+                .map(GroupMember::getGroup)
+                .filter(this::isEndGroup)
+                .toList();
+    }
+
+    private boolean isNotEndEstimate(GroupMember groupMember) {
+        return !groupMember.isEndEstimate();
+    }
+
+    private boolean isEndGroup(Group group) {
+        return group.getStartDateTime().isBefore(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/gloddy/server/myGroup/read/domainService/ParticipatingGroupGetExecutor.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/domainService/ParticipatingGroupGetExecutor.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 
 import static java.util.Comparator.*;
@@ -26,7 +27,7 @@ public class ParticipatingGroupGetExecutor {
         return groupMembers.stream()
                 .filter(groupMember -> isNotCaptain(groupMember.getGroup(), userId))
                 .filter(groupMember -> isNotEndGroup(groupMember.getGroup()))
-                .sorted(comparing(this::getGroupMemberCreatedAt).reversed())
+                .sorted(groupMemberCreatedAtDesc())
                 .map(groupMember -> MyGroupDtoMapper.mapToParticipatingOne(isNewGroupMember(groupMember), groupMember.getGroup()))
                 .collect(collectingAndThen(toList(), MyGroupResponse.Participating::new));
     }
@@ -36,14 +37,14 @@ public class ParticipatingGroupGetExecutor {
     }
 
     private boolean isNotEndGroup(Group group) {
-        return group.getDateTime().getStartDateTime().isAfter(LocalDateTime.now());
+        return !group.isEndGroup();
     }
 
-    private LocalDateTime getGroupMemberCreatedAt(GroupMember groupMember) {
-        return groupMember.getCreatedAt();
+    private Comparator<? super GroupMember> groupMemberCreatedAtDesc() {
+        return comparing(GroupMember::getCreatedAt).reversed();
     }
 
     private boolean isNewGroupMember(GroupMember groupMember) {
-        return groupMember.getCreatedAt().isAfter(LocalDateTime.now().minusHours(1));
+        return groupMember.isNewGroupMember();
     }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/domainService/ParticipatingGroupGetExecutor.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/domainService/ParticipatingGroupGetExecutor.java
@@ -1,0 +1,49 @@
+package com.gloddy.server.myGroup.read.domainService;
+
+import com.gloddy.server.group.domain.Group;
+import com.gloddy.server.group_member.domain.GroupMember;
+import com.gloddy.server.group_member.domain.handler.GroupMemberQueryHandler;
+import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
+import com.gloddy.server.myGroup.read.util.MyGroupDtoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static java.util.Comparator.*;
+import static java.util.stream.Collectors.*;
+
+@Component
+@RequiredArgsConstructor
+public class ParticipatingGroupGetExecutor {
+
+    private final GroupMemberQueryHandler groupMemberQueryHandler;
+
+    public MyGroupResponse.Participating getParticipatingGroups(Long userId) {
+        List<GroupMember> groupMembers = groupMemberQueryHandler.findAllByUserId(userId);
+
+        return groupMembers.stream()
+                .filter(groupMember -> isNotCaptain(groupMember.getGroup(), userId))
+                .filter(groupMember -> isNotEndGroup(groupMember.getGroup()))
+                .sorted(comparing(this::getGroupMemberCreatedAt).reversed())
+                .map(groupMember -> MyGroupDtoMapper.mapToParticipatingOne(isNewGroupMember(groupMember), groupMember.getGroup()))
+                .collect(collectingAndThen(toList(), MyGroupResponse.Participating::new));
+    }
+
+    private boolean isNotCaptain(Group group, Long userId) {
+        return !group.getCaptain().getId().equals(userId);
+    }
+
+    private boolean isNotEndGroup(Group group) {
+        return group.getDateTime().getStartDateTime().isAfter(LocalDateTime.now());
+    }
+
+    private LocalDateTime getGroupMemberCreatedAt(GroupMember groupMember) {
+        return groupMember.getCreatedAt();
+    }
+
+    private boolean isNewGroupMember(GroupMember groupMember) {
+        return groupMember.getCreatedAt().isAfter(LocalDateTime.now().minusHours(1));
+    }
+}

--- a/src/main/java/com/gloddy/server/myGroup/read/domainService/RejectedGroupGetExecutor.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/domainService/RejectedGroupGetExecutor.java
@@ -1,0 +1,40 @@
+package com.gloddy.server.myGroup.read.domainService;
+
+import com.gloddy.server.apply.domain.Apply;
+import com.gloddy.server.apply.domain.handler.ApplyQueryHandler;
+import com.gloddy.server.apply.domain.vo.Status;
+import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
+import com.gloddy.server.myGroup.read.util.MyGroupDtoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Comparator.comparing;
+
+@Component
+@RequiredArgsConstructor
+public class RejectedGroupGetExecutor {
+
+    private final ApplyQueryHandler applyQueryHandler;
+
+    public MyGroupResponse.Rejected getRejectedGroups(Long userId) {
+        List<Apply> refusedApply = applyQueryHandler.findAllByUserIdAndStatus(userId, Status.REFUSE);
+
+        return refusedApply.stream()
+                .sorted(applyUpdatedAttDesc())
+                .filter(this::isNotCheckRejected)
+                .map(apply -> MyGroupDtoMapper.mapToRejectedOne(apply.getId(), apply.getGroup()))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), MyGroupResponse.Rejected::new));
+    }
+
+    private Comparator<? super Apply> applyUpdatedAttDesc() {
+        return comparing(Apply::getUpdatedAt).reversed();
+    }
+
+    private boolean isNotCheckRejected(Apply apply) {
+        return !apply.isCheckRejected();
+    }
+}

--- a/src/main/java/com/gloddy/server/myGroup/read/domainService/WaitingGroupGetExecutor.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/domainService/WaitingGroupGetExecutor.java
@@ -1,0 +1,43 @@
+package com.gloddy.server.myGroup.read.domainService;
+
+import com.gloddy.server.apply.domain.Apply;
+import com.gloddy.server.apply.domain.handler.ApplyQueryHandler;
+import com.gloddy.server.apply.domain.vo.Status;
+import com.gloddy.server.group.domain.Group;
+import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
+import com.gloddy.server.myGroup.read.util.MyGroupDtoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+import static java.util.Comparator.*;
+import static java.util.stream.Collectors.*;
+
+@Component
+@RequiredArgsConstructor
+public class WaitingGroupGetExecutor {
+
+    private final ApplyQueryHandler applyQueryHandler;
+
+    public MyGroupResponse.Waiting getWaitingGroups(Long userId) {
+        List<Apply> waitApplies = applyQueryHandler.findAllByUserIdAndStatus(userId, Status.WAIT);
+
+        return waitApplies.stream()
+                .sorted(applyCreatedAtDesc())
+                .map(Apply::getGroup)
+                .filter(this::isNotEndGroup)
+                .map(MyGroupDtoMapper::mapToWaitingOne)
+                .collect(collectingAndThen(toList(), MyGroupResponse.Waiting::new));
+    }
+
+    private boolean isNotEndGroup(Group group) {
+        return group.getDateTime().getStartDateTime().isAfter(LocalDateTime.now());
+    }
+
+    private Comparator<? super Apply> applyCreatedAtDesc() {
+        return comparing(Apply::getCreatedAt).reversed();
+    }
+}

--- a/src/main/java/com/gloddy/server/myGroup/read/domainService/WaitingGroupGetExecutor.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/domainService/WaitingGroupGetExecutor.java
@@ -34,7 +34,7 @@ public class WaitingGroupGetExecutor {
     }
 
     private boolean isNotEndGroup(Group group) {
-        return group.getDateTime().getStartDateTime().isAfter(LocalDateTime.now());
+        return !group.isEndGroup();
     }
 
     private Comparator<? super Apply> applyCreatedAtDesc() {

--- a/src/main/java/com/gloddy/server/myGroup/read/domainService/facade/HostingGroupGetFacade.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/domainService/facade/HostingGroupGetFacade.java
@@ -1,0 +1,32 @@
+package com.gloddy.server.myGroup.read.domainService.facade;
+
+import com.gloddy.server.group.domain.Group;
+import com.gloddy.server.myGroup.read.domainService.HostingGroupExistNewApplyChecker;
+import com.gloddy.server.myGroup.read.domainService.HostingGroupGetExecutor;
+import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
+import com.gloddy.server.myGroup.read.util.MyGroupDtoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.*;
+
+@Component
+@RequiredArgsConstructor
+public class HostingGroupGetFacade {
+
+    private final HostingGroupGetExecutor hostingGroupGetExecutor;
+    private final HostingGroupExistNewApplyChecker hostingGroupExistNewApplyChecker;
+
+    public MyGroupResponse.Hosting getHostingGroups(Long userId) {
+        List<Group> hostingGroups = hostingGroupGetExecutor.getHostingGroups(userId);
+
+        return hostingGroups.stream()
+                .map(group -> {
+                    boolean isExistNewApply = hostingGroupExistNewApplyChecker.isExistNewApply(group.getId());
+                    return MyGroupDtoMapper.matToHostingOne(isExistNewApply, group);
+                })
+                .collect(collectingAndThen(toList(), MyGroupResponse.Hosting::new));
+    }
+}

--- a/src/main/java/com/gloddy/server/myGroup/read/dto/MyGroupResponse.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/dto/MyGroupResponse.java
@@ -68,4 +68,19 @@ public class MyGroupResponse {
             private GroupInfo group;
         }
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Rejected {
+        private List<One> groups;
+
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class One {
+            private Long applyId;
+            private GroupInfo group;
+        }
+    }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/dto/MyGroupResponse.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/dto/MyGroupResponse.java
@@ -55,4 +55,17 @@ public class MyGroupResponse {
             private GroupInfo group;
         }
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Waiting {
+        private List<One> groups;
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class One {
+            private GroupInfo group;
+        }
+    }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/dto/MyGroupResponse.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/dto/MyGroupResponse.java
@@ -83,4 +83,19 @@ public class MyGroupResponse {
             private GroupInfo group;
         }
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NotEstimated {
+        private List<One> groups;
+
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class One {
+            private Boolean isCaptain;
+            private GroupInfo group;
+        }
+    }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/dto/MyGroupResponse.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/dto/MyGroupResponse.java
@@ -40,4 +40,19 @@ public class MyGroupResponse {
             private GroupInfo group;
         }
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Hosting {
+        private List<One> groups;
+
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class One {
+            private Boolean isExistNewApply;
+            private GroupInfo group;
+        }
+    }
 }

--- a/src/main/java/com/gloddy/server/myGroup/read/dto/MyGroupResponse.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/dto/MyGroupResponse.java
@@ -1,0 +1,43 @@
+package com.gloddy.server.myGroup.read.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class MyGroupResponse {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GroupInfo {
+        private Long groupId;
+        private String imageUrl;
+        private String title;
+        private String content;
+        private int memberCount;
+        private int maxMemberCount;
+        private String placeName;
+        private String placeAddress;
+        private String meetDate;
+        private String startTime;
+        private String endTime;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Participating {
+
+        private List<One> groups;
+
+        @Getter
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class One {
+            private Boolean isNew;
+            private GroupInfo group;
+        }
+    }
+}

--- a/src/main/java/com/gloddy/server/myGroup/read/util/MyGroupDtoMapper.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/util/MyGroupDtoMapper.java
@@ -25,6 +25,13 @@ public class MyGroupDtoMapper {
         );
     }
 
+    public static MyGroupResponse.Rejected.One mapToRejectedOne(Long applyId, Group group) {
+        return new MyGroupResponse.Rejected.One(
+                applyId,
+                mapToGroupInfo(group)
+        );
+    }
+
     private static MyGroupResponse.GroupInfo mapToGroupInfo(Group group) {
         return new MyGroupResponse.GroupInfo(
                 group.getId(),

--- a/src/main/java/com/gloddy/server/myGroup/read/util/MyGroupDtoMapper.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/util/MyGroupDtoMapper.java
@@ -19,6 +19,12 @@ public class MyGroupDtoMapper {
         );
     }
 
+    public static MyGroupResponse.Waiting.One mapToWaitingOne(Group group) {
+        return new MyGroupResponse.Waiting.One(
+                mapToGroupInfo(group)
+        );
+    }
+
     private static MyGroupResponse.GroupInfo mapToGroupInfo(Group group) {
         return new MyGroupResponse.GroupInfo(
                 group.getId(),

--- a/src/main/java/com/gloddy/server/myGroup/read/util/MyGroupDtoMapper.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/util/MyGroupDtoMapper.java
@@ -12,6 +12,13 @@ public class MyGroupDtoMapper {
         );
     }
 
+    public static MyGroupResponse.Hosting.One matToHostingOne(boolean isExistNewApply, Group group) {
+        return new MyGroupResponse.Hosting.One(
+                isExistNewApply,
+                mapToGroupInfo(group)
+        );
+    }
+
     private static MyGroupResponse.GroupInfo mapToGroupInfo(Group group) {
         return new MyGroupResponse.GroupInfo(
                 group.getId(),

--- a/src/main/java/com/gloddy/server/myGroup/read/util/MyGroupDtoMapper.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/util/MyGroupDtoMapper.java
@@ -1,0 +1,30 @@
+package com.gloddy.server.myGroup.read.util;
+
+import com.gloddy.server.group.domain.Group;
+import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
+
+public class MyGroupDtoMapper {
+
+    public static MyGroupResponse.Participating.One mapToParticipatingOne(boolean isNew, Group group) {
+        return new MyGroupResponse.Participating.One(
+                isNew,
+                mapToGroupInfo(group)
+        );
+    }
+
+    private static MyGroupResponse.GroupInfo mapToGroupInfo(Group group) {
+        return new MyGroupResponse.GroupInfo(
+                group.getId(),
+                group.getImageUrl(),
+                group.getTitle(),
+                group.getContent(),
+                group.getMemberCount(),
+                group.getMaxUser(),
+                group.getPlace().getName(),
+                group.getPlace().getAddress(),
+                group.getMeetDate().toString(),
+                group.getStartDateTime().toLocalTime().toString(),
+                group.getEndDateTime().toLocalTime().toString()
+        );
+    }
+}

--- a/src/main/java/com/gloddy/server/myGroup/read/util/MyGroupDtoMapper.java
+++ b/src/main/java/com/gloddy/server/myGroup/read/util/MyGroupDtoMapper.java
@@ -32,6 +32,13 @@ public class MyGroupDtoMapper {
         );
     }
 
+    public static MyGroupResponse.NotEstimated.One mapToNotEstimatedOne(Long userId, Group group) {
+        return new MyGroupResponse.NotEstimated.One(
+                group.getCaptain().getId().equals(userId),
+                mapToGroupInfo(group)
+        );
+    }
+
     private static MyGroupResponse.GroupInfo mapToGroupInfo(Group group) {
         return new MyGroupResponse.GroupInfo(
                 group.getId(),

--- a/src/main/java/com/gloddy/server/scrap/application/ScrapService.java
+++ b/src/main/java/com/gloddy/server/scrap/application/ScrapService.java
@@ -49,7 +49,10 @@ public class ScrapService {
                 group.getMemberCount(),
                 group.getMaxUser(),
                 group.getPlace().getName(),
-                group.getMeetDate().toString()
+                group.getPlace().getAddress(),
+                group.getMeetDate().toString(),
+                group.getStartDateTime().toLocalTime().toString(),
+                group.getEndDateTime().toLocalTime().toString()
         );
     }
 

--- a/src/test/java/com/gloddy/server/acceptance/apply/UpdateApplyTest.java
+++ b/src/test/java/com/gloddy/server/acceptance/apply/UpdateApplyTest.java
@@ -116,7 +116,7 @@ public class UpdateApplyTest extends ApplyApiTest {
             assertThat(groupMember.getGroup().getId()).isEqualTo(group.getId());
             assertThat(groupMember.getUser().getId()).isEqualTo(user.getId());
             assertThat(groupMember.isEnd()).isEqualTo(false);
-            assertThat(groupMember.isPraised()).isEqualTo(false);
+            assertThat(groupMember.isEndEstimate()).isEqualTo(false);
             assertThat(groupMember.getAbsenceVoteCount()).isEqualTo(0);
             assertThat(groupMember.isAbsence()).isFalse();
 

--- a/src/test/java/com/gloddy/server/acceptance/group/CreateGroupTest.java
+++ b/src/test/java/com/gloddy/server/acceptance/group/CreateGroupTest.java
@@ -68,7 +68,7 @@ public class CreateGroupTest extends GroupApiTest {
         assertThat(groupMember.getUser().getId()).isEqualTo(user.getId());
         assertThat(groupMember.getGroup().getId()).isEqualTo(group.getId());
         assertThat(groupMember.isEnd()).isEqualTo(false);
-        assertThat(groupMember.isPraised()).isEqualTo(false);
+        assertThat(groupMember.isEndEstimate()).isEqualTo(false);
         assertThat(groupMember.getAbsenceVoteCount()).isEqualTo(0);
         assertThat(groupMember.isAbsence()).isFalse();
 

--- a/src/test/java/com/gloddy/server/acceptance/group/GetExpectedGroupTest.java
+++ b/src/test/java/com/gloddy/server/acceptance/group/GetExpectedGroupTest.java
@@ -39,7 +39,7 @@ public class GetExpectedGroupTest extends GroupApiTest {
         test.andExpect(status().isOk());
         test.andExpect(jsonPath("groups.size()").value(1));
         test.andExpect(jsonPath("groups[0].groupId").value(expectedGroup.getId()));
-        test.andExpect(jsonPath("groups[0].meetDate").value(dateToStringForGroupPreview(expectedGroup.getStartDateTime())));
+        test.andExpect(jsonPath("groups[0].meetDate").value(expectedGroup.getMeetDate().toString()));
     }
 
 }

--- a/src/test/java/com/gloddy/server/common/BaseServiceTest.java
+++ b/src/test/java/com/gloddy/server/common/BaseServiceTest.java
@@ -7,6 +7,7 @@ import com.gloddy.server.auth.domain.vo.kind.Gender;
 import com.gloddy.server.auth.domain.vo.kind.Personality;
 import com.gloddy.server.group.infra.repository.GroupJpaRepository;
 import com.gloddy.server.group_member.infra.repository.GroupMemberJpaRepository;
+import com.gloddy.server.mate.infra.repository.MateJpaRepository;
 import com.gloddy.server.praise.infra.repository.PraiseJpaRepository;
 import com.gloddy.server.reliability.infra.repository.ReliabilityRepository;
 import com.gloddy.server.user.infra.repository.UserJpaRepository;
@@ -32,9 +33,11 @@ public abstract class BaseServiceTest {
     @Autowired
     private ApplyJpaRepository applyJpaRepository;
     @Autowired
-    private GroupJpaRepository groupJpaRepository;
+    protected GroupJpaRepository groupJpaRepository;
     @Autowired
-    private GroupMemberJpaRepository groupMemberJpaRepository;
+    protected GroupMemberJpaRepository groupMemberJpaRepository;
+    @Autowired
+    private MateJpaRepository mateJpaRepository;
 
     @Autowired
     private AuthService authService;
@@ -71,6 +74,7 @@ public abstract class BaseServiceTest {
         groupJpaRepository.deleteAll();
         praiseJpaRepository.deleteAll();
         reliabilityRepository.deleteAll();
+        mateJpaRepository.deleteAll();
         userJpaRepository.deleteAll();
     }
 }

--- a/src/test/java/com/gloddy/server/common/BaseServiceTest.java
+++ b/src/test/java/com/gloddy/server/common/BaseServiceTest.java
@@ -1,0 +1,76 @@
+package com.gloddy.server.common;
+
+import com.gloddy.server.apply.infra.repository.ApplyJpaRepository;
+import com.gloddy.server.auth.application.AuthService;
+import com.gloddy.server.auth.domain.dto.AuthRequest;
+import com.gloddy.server.auth.domain.vo.kind.Gender;
+import com.gloddy.server.auth.domain.vo.kind.Personality;
+import com.gloddy.server.group.infra.repository.GroupJpaRepository;
+import com.gloddy.server.group_member.infra.repository.GroupMemberJpaRepository;
+import com.gloddy.server.praise.infra.repository.PraiseJpaRepository;
+import com.gloddy.server.reliability.infra.repository.ReliabilityRepository;
+import com.gloddy.server.user.infra.repository.UserJpaRepository;
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Random;
+
+@SpringBootTest
+@Transactional
+public abstract class BaseServiceTest {
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+    @Autowired
+    private PraiseJpaRepository praiseJpaRepository;
+    @Autowired
+    private ReliabilityRepository reliabilityRepository;
+    @Autowired
+    private ApplyJpaRepository applyJpaRepository;
+    @Autowired
+    private GroupJpaRepository groupJpaRepository;
+    @Autowired
+    private GroupMemberJpaRepository groupMemberJpaRepository;
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    protected EntityManager em;
+
+    public Long createUser() {
+
+        Random rand = new Random();
+        int number2 = rand.nextInt((9999 - 1000) + 1) + 1000;
+        int number3 = rand.nextInt((9999 - 1000) + 1) + 1000;
+
+        AuthRequest.SignUp command = new AuthRequest.SignUp(
+                "010" + "-" + number2 + "-" + number3,
+                "imageUrl",
+                new AuthRequest.SignUp.School(
+                        false,
+                        "숭실대학교",
+                        null
+                ),
+                "nickName",
+                LocalDate.now(),
+                Gender.MAIL,
+                List.of(Personality.KIND, Personality.ACTIVE, Personality.RESPONSIBLE)
+        );
+
+        return authService.signUp(command).getUserId();
+    }
+
+    protected void clear() {
+        groupMemberJpaRepository.deleteAll();
+        applyJpaRepository.deleteAll();
+        groupJpaRepository.deleteAll();
+        praiseJpaRepository.deleteAll();
+        reliabilityRepository.deleteAll();
+        userJpaRepository.deleteAll();
+    }
+}

--- a/src/test/java/com/gloddy/server/common/group/GroupApiTest.java
+++ b/src/test/java/com/gloddy/server/common/group/GroupApiTest.java
@@ -40,7 +40,7 @@ abstract public class GroupApiTest extends BaseApiTest {
     protected GroupMember createCompletePraiseUserGroup(User user, Group group) {
         GroupMember groupMember = GroupMember.empty();
         groupMember.init(user, group);
-        groupMember.completePraise();
+        groupMember.completeEstimate();
         return groupMemberJpaRepository.save(groupMember);
     }
 

--- a/src/test/java/com/gloddy/server/common/myGroup/MyGroupServiceTest.java
+++ b/src/test/java/com/gloddy/server/common/myGroup/MyGroupServiceTest.java
@@ -1,0 +1,55 @@
+package com.gloddy.server.common.myGroup;
+
+import com.gloddy.server.apply.application.ApplyService;
+import com.gloddy.server.apply.domain.dto.ApplyRequest;
+import com.gloddy.server.apply.domain.vo.Status;
+import com.gloddy.server.common.BaseServiceTest;
+import com.gloddy.server.group.application.GroupService;
+import com.gloddy.server.group.domain.dto.GroupRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+
+public abstract class MyGroupServiceTest extends BaseServiceTest {
+
+    @Autowired
+    protected GroupService groupService;
+
+    @Autowired
+    protected ApplyService applyService;
+
+    protected GroupRequest.Create createGroupCreateCommand(LocalDate meetDate, String startTime, String endTime) {
+        return new GroupRequest.Create(
+                "imageUrl",
+                "title",
+                "content",
+                meetDate,
+                startTime,
+                endTime,
+                "placeName",
+                "placeAddress",
+                "130",
+                "25",
+                10
+        );
+    }
+
+    protected ApplyRequest.Create createApplyCreateCommand() {
+        return new ApplyRequest.Create(
+                "introduce",
+                "reason"
+        );
+    }
+
+    protected Long createGroup(Long captainId, GroupRequest.Create command) {
+        return groupService.createGroup(captainId, command).getGroupId();
+    }
+
+    protected Long createApply(Long userId, Long groupId, ApplyRequest.Create command) {
+        return applyService.createApply(userId, groupId, command).getApplyId();
+    }
+
+    protected void approveApply(Long captainId, Long applyId) {
+        applyService.updateStatusApply(captainId, null, applyId, Status.APPROVE);
+    }
+}

--- a/src/test/java/com/gloddy/server/common/myGroup/MyGroupServiceTest.java
+++ b/src/test/java/com/gloddy/server/common/myGroup/MyGroupServiceTest.java
@@ -52,4 +52,12 @@ public abstract class MyGroupServiceTest extends BaseServiceTest {
     protected void approveApply(Long captainId, Long applyId) {
         applyService.updateStatusApply(captainId, null, applyId, Status.APPROVE);
     }
+
+    protected void refuseApply(Long captainId, Long applyId) {
+        applyService.updateStatusApply(captainId, null, applyId, Status.REFUSE);
+    }
+
+    protected void checkRejectedApply(Long userId, Long applyId) {
+        applyService.checkRejectedApply(userId, applyId);
+    }
 }

--- a/src/test/java/com/gloddy/server/common/myGroup/MyGroupServiceTest.java
+++ b/src/test/java/com/gloddy/server/common/myGroup/MyGroupServiceTest.java
@@ -6,9 +6,13 @@ import com.gloddy.server.apply.domain.vo.Status;
 import com.gloddy.server.common.BaseServiceTest;
 import com.gloddy.server.group.application.GroupService;
 import com.gloddy.server.group.domain.dto.GroupRequest;
+import com.gloddy.server.group_member.application.GroupMemberService;
+import com.gloddy.server.group_member.domain.dto.GroupMemberRequest;
+import com.gloddy.server.praise.domain.vo.PraiseValue;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public abstract class MyGroupServiceTest extends BaseServiceTest {
 
@@ -17,6 +21,9 @@ public abstract class MyGroupServiceTest extends BaseServiceTest {
 
     @Autowired
     protected ApplyService applyService;
+
+    @Autowired
+    protected GroupMemberService groupMemberService;
 
     protected GroupRequest.Create createGroupCreateCommand(LocalDate meetDate, String startTime, String endTime) {
         return new GroupRequest.Create(
@@ -59,5 +66,15 @@ public abstract class MyGroupServiceTest extends BaseServiceTest {
 
     protected void checkRejectedApply(Long userId, Long applyId) {
         applyService.checkRejectedApply(userId, applyId);
+    }
+
+    protected GroupMemberRequest.Estimate createEstimateCommand(List<Long> praisedUserId, Long matedUserId) {
+
+        List<GroupMemberRequest.Estimate.PraiseInfo> praiseInfos = praisedUserId.stream()
+                .map(it -> new GroupMemberRequest.Estimate.PraiseInfo(it, PraiseValue.KIND))
+                .toList();
+        GroupMemberRequest.Estimate.MateInfo mateInfo = new GroupMemberRequest.Estimate.MateInfo(matedUserId, "reason");
+
+        return new GroupMemberRequest.Estimate(praiseInfos, mateInfo);
     }
 }

--- a/src/test/java/com/gloddy/server/service/myGroup/GetHostingGroupTest.java
+++ b/src/test/java/com/gloddy/server/service/myGroup/GetHostingGroupTest.java
@@ -1,0 +1,134 @@
+package com.gloddy.server.service.myGroup;
+
+import com.gloddy.server.apply.domain.dto.ApplyRequest;
+import com.gloddy.server.common.myGroup.MyGroupServiceTest;
+import com.gloddy.server.group.domain.dto.GroupRequest;
+import com.gloddy.server.myGroup.read.MyGroupReadService;
+import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Commit;
+import org.springframework.test.context.transaction.AfterTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class GetHostingGroupTest extends MyGroupServiceTest {
+
+    @Autowired
+    private MyGroupReadService myGroupReadService;
+
+    @Nested
+    class Case1 {
+
+        private Long targetUserId;
+        private Long groupId1;
+        private Long groupId2;
+
+        @Test
+        @Commit
+        void getHostingGroups_returns_all() {
+            //given
+            Long captainId = createUser();
+            GroupRequest.Create groupCreateCommand1 = createGroupCreateCommand(LocalDate.now().plusDays(1), "12:00", "13:00");
+            GroupRequest.Create groupCreateCommand2 = createGroupCreateCommand(LocalDate.now().plusDays(2), "12:00", "13:00");
+            groupId1 = createGroup(captainId, groupCreateCommand1);
+            groupId2 = createGroup(captainId, groupCreateCommand2);
+
+            targetUserId = captainId;
+        }
+
+        @AfterTransaction
+        @Transactional
+        @Commit
+        void when_and_then() {
+            //when
+            MyGroupResponse.Hosting hostingGroups = myGroupReadService.getHostingGroups(targetUserId);
+
+            //then
+            assertThat(hostingGroups.getGroups()).hasSize(2);
+            assertThat(hostingGroups.getGroups().get(0).getIsExistNewApply()).isFalse();
+            assertThat(hostingGroups.getGroups().get(1).getIsExistNewApply()).isFalse();
+            assertThat(hostingGroups.getGroups().get(0).getGroup().getGroupId()).isEqualTo(groupId2);
+            assertThat(hostingGroups.getGroups().get(1).getGroup().getGroupId()).isEqualTo(groupId1);
+
+            //after
+            clear();
+        }
+    }
+
+    @Nested
+    class Case2 {
+
+        Long targetUserId;
+
+        @Test
+        @Commit
+        void getHostingGroups_returns_empty_list_when_no_hostingGroups() {
+            //given
+            Long captainId = createUser();
+            GroupRequest.Create groupCreateCommand1 = createGroupCreateCommand(LocalDate.now().plusDays(1), "12:00", "13:00");
+            Long groupId1 = createGroup(captainId, groupCreateCommand1);
+
+            targetUserId = createUser();
+            ApplyRequest.Create applyCreateCommand = createApplyCreateCommand();
+            Long applyId1 = createApply(targetUserId, groupId1, applyCreateCommand);
+
+            approveApply(captainId, applyId1);
+        }
+
+        @AfterTransaction
+        @Transactional
+        @Commit
+        void when_and_then() {
+            //when
+            MyGroupResponse.Hosting hostingGroups = myGroupReadService.getHostingGroups(targetUserId);
+
+            //then
+            assertThat(hostingGroups.getGroups()).isEmpty();
+
+            //after
+            clear();
+        }
+    }
+
+    @Nested
+    class Case3 {
+
+        Long targetUserId;
+        Long groupId;
+
+        @Test
+        @Commit
+        void getHostingGroups_returns_all_with_new_apply() {
+            //given
+            Long captainId = createUser();
+            GroupRequest.Create groupCreateCommand1 = createGroupCreateCommand(LocalDate.now().plusDays(1), "12:00", "13:00");
+            groupId = createGroup(captainId, groupCreateCommand1);
+
+            Long applierId = createUser();
+            ApplyRequest.Create applyCreateCommand = createApplyCreateCommand();
+            createApply(applierId, groupId, applyCreateCommand);
+
+            targetUserId = captainId;
+        }
+
+        @AfterTransaction
+        @Transactional
+        @Commit
+        void when_and_then() {
+            //when
+            MyGroupResponse.Hosting hostingGroups = myGroupReadService.getHostingGroups(targetUserId);
+
+            //then
+            assertThat(hostingGroups.getGroups()).hasSize(1);
+            assertThat(hostingGroups.getGroups().get(0).getIsExistNewApply()).isTrue();
+            assertThat(hostingGroups.getGroups().get(0).getGroup().getGroupId()).isEqualTo(groupId);
+
+            clear();
+        }
+    }
+}

--- a/src/test/java/com/gloddy/server/service/myGroup/GetNotEstimatedGroupTest.java
+++ b/src/test/java/com/gloddy/server/service/myGroup/GetNotEstimatedGroupTest.java
@@ -1,0 +1,123 @@
+package com.gloddy.server.service.myGroup;
+
+import com.gloddy.server.apply.domain.dto.ApplyRequest;
+import com.gloddy.server.common.myGroup.MyGroupServiceTest;
+import com.gloddy.server.group.domain.dto.GroupRequest;
+import com.gloddy.server.group_member.domain.dto.GroupMemberRequest;
+import com.gloddy.server.myGroup.read.MyGroupReadService;
+import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Commit;
+import org.springframework.test.context.transaction.AfterTransaction;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class GetNotEstimatedGroupTest extends MyGroupServiceTest {
+
+    @Autowired
+    private MyGroupReadService myGroupReadService;
+
+    @Nested
+    class Case1 {
+
+        private Long targetUserId;
+        private Long groupId;
+
+        @Test
+        @Commit
+        void getNotEstimatedGroups_returns_all() {
+            //given
+            Long captainId = createUser();
+            GroupRequest.Create groupCreateCommand = createGroupCreateCommand(
+                    LocalDate.now().minusDays(1),
+                    "12:00",
+                    "13:00");
+            groupId = createGroup(captainId, groupCreateCommand);
+
+            Long applierId = createUser();
+            ApplyRequest.Create applyCreateCommand = createApplyCreateCommand();
+            Long applyId = createApply(applierId, groupId, applyCreateCommand);
+
+            approveApply(captainId, applyId);
+
+            targetUserId = applierId;
+        }
+
+        @AfterTransaction
+        @Transactional
+        @Commit
+        void when_and_then() {
+            //when
+            MyGroupResponse.NotEstimated notEstimatedGroups = myGroupReadService.getNotEstimatedGroups(targetUserId);
+
+            //then
+            assertThat(notEstimatedGroups.getGroups()).hasSize(1);
+            assertThat(notEstimatedGroups.getGroups().get(0).getIsCaptain()).isFalse();
+            assertThat(notEstimatedGroups.getGroups().get(0).getGroup().getGroupId()).isEqualTo(groupId);
+
+            //after
+            clear();
+        }
+    }
+
+    @Nested
+    class Case2 {
+
+        private Long captainId;
+        private Long groupId;
+        private Long targetUserId;
+
+        @BeforeEach
+        void given() {
+            //given...
+            captainId = createUser();
+            GroupRequest.Create groupCreateCommand = createGroupCreateCommand(
+                    LocalDate.now().minusDays(1),
+                    "12:00",
+                    "13:00");
+            groupId = createGroup(captainId, groupCreateCommand);
+
+            Long applierId = createUser();
+            ApplyRequest.Create applyCreateCommand = createApplyCreateCommand();
+            Long applyId = createApply(applierId, groupId, applyCreateCommand);
+
+            approveApply(captainId, applyId);
+
+            targetUserId = applierId;
+
+            TestTransaction.end();
+        }
+
+        @Test
+        @Transactional
+        @Commit
+        void getNotEstimatedGroups_returns_empty_list_when_all_end_estimate() {
+            //after_event_given
+            GroupMemberRequest.Estimate estimateCommand = createEstimateCommand(List.of(captainId), captainId);
+            groupMemberService.estimateGroupMembers(estimateCommand, targetUserId, groupId);
+
+        }
+
+        @AfterTransaction
+        @Transactional
+        @Commit
+        void when_and_then() {
+            //when
+            MyGroupResponse.NotEstimated notEstimatedGroups = myGroupReadService.getNotEstimatedGroups(targetUserId);
+
+            //then
+            assertThat(notEstimatedGroups.getGroups()).isEmpty();
+
+            //after
+            clear();
+        }
+    }
+}

--- a/src/test/java/com/gloddy/server/service/myGroup/GetParticipatingGroupTest.java
+++ b/src/test/java/com/gloddy/server/service/myGroup/GetParticipatingGroupTest.java
@@ -1,0 +1,139 @@
+package com.gloddy.server.service.myGroup;
+
+import com.gloddy.server.apply.domain.dto.ApplyRequest;
+import com.gloddy.server.common.myGroup.MyGroupServiceTest;
+import com.gloddy.server.group.domain.dto.GroupRequest;
+import com.gloddy.server.myGroup.read.MyGroupReadService;
+import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Commit;
+import org.springframework.test.context.transaction.AfterTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class GetParticipatingGroupTest extends MyGroupServiceTest {
+
+    @Autowired
+    private MyGroupReadService myGroupReadService;
+
+    @Nested
+    class getParticipatingGroups_returns_all {
+        Long targetUserId;
+        Long groupId1;
+        Long groupId2;
+
+        @Test
+        @Commit
+        void start() {
+            //given
+            Long captainId = createUser();
+            GroupRequest.Create groupCreateCommand1 = createGroupCreateCommand(LocalDate.now().plusDays(1), "12:00", "13:00");
+            GroupRequest.Create groupCreateCommand2 = createGroupCreateCommand(LocalDate.now().plusDays(2), "12:00", "13:00");
+            groupId1 = createGroup(captainId, groupCreateCommand1);
+            groupId2 = createGroup(captainId, groupCreateCommand2);
+
+            targetUserId = createUser();
+            ApplyRequest.Create applyCreateCommand = createApplyCreateCommand();
+            Long applyId1 = createApply(targetUserId, groupId1, applyCreateCommand);
+            Long applyId2 = createApply(targetUserId, groupId2, applyCreateCommand);
+
+            approveApply(captainId, applyId1);
+            approveApply(captainId, applyId2);
+        }
+
+        @AfterTransaction
+        @Transactional
+        @Commit
+        void when_and_then() {
+            //when
+            MyGroupResponse.Participating participatingGroups = myGroupReadService.getParticipatingGroups(targetUserId);
+
+            //then
+            assertThat(participatingGroups.getGroups()).hasSize(2);
+            assertThat(participatingGroups.getGroups().get(0).getIsNew()).isTrue();
+            assertThat(participatingGroups.getGroups().get(0).getGroup().getGroupId()).isEqualTo(groupId2);
+            assertThat(participatingGroups.getGroups().get(1).getIsNew()).isTrue();
+            assertThat(participatingGroups.getGroups().get(1).getGroup().getGroupId()).isEqualTo(groupId1);
+
+            //after
+            clear();
+        }
+    }
+
+    @Nested
+    class getParticipatingGroups_returns_empty_list_when_all_groups_captain {
+
+        private Long targetUserId;
+
+        @Test
+        @Commit
+        void start() {
+            //given
+            Long captainId = createUser();
+            GroupRequest.Create groupCreateCommand1 = createGroupCreateCommand(LocalDate.now().plusDays(1), "12:00", "13:00");
+            createGroup(captainId, groupCreateCommand1);
+
+            targetUserId = captainId;
+        }
+
+        @AfterTransaction
+        @Transactional
+        @Commit
+        void when_and_then() {
+
+            //when
+            MyGroupResponse.Participating participatingGroups = myGroupReadService.getParticipatingGroups(targetUserId);
+
+            //then
+            assertThat(participatingGroups.getGroups()).isEmpty();
+
+            //after
+            clear();
+        }
+    }
+
+    @Nested
+    class getParticipatingGroups_returns_empty_list_when_all_groups_end {
+
+        private Long targetUserId;
+
+        @Test
+        @Commit
+        void start() {
+            //given
+            Long captainId = createUser();
+            GroupRequest.Create groupCreateCommand1 = createGroupCreateCommand(LocalDate.now().minusDays(1), "12:00", "13:00");
+            GroupRequest.Create groupCreateCommand2 = createGroupCreateCommand(LocalDate.now().minusDays(2), "12:00", "13:00");
+            Long groupId1 = createGroup(captainId, groupCreateCommand1);
+            Long groupId2 = createGroup(captainId, groupCreateCommand2);
+
+            targetUserId = createUser();
+            ApplyRequest.Create applyCreateCommand = createApplyCreateCommand();
+            Long applyId1 = createApply(targetUserId, groupId1, applyCreateCommand);
+            Long applyId2 = createApply(targetUserId, groupId2, applyCreateCommand);
+
+            approveApply(captainId, applyId1);
+            approveApply(captainId, applyId2);
+        }
+
+        @AfterTransaction
+        @Transactional
+        @Commit
+        void when_and_then() {
+
+            //when
+            MyGroupResponse.Participating participatingGroups = myGroupReadService.getParticipatingGroups(targetUserId);
+
+            //then
+            assertThat(participatingGroups.getGroups()).isEmpty();
+
+            //after
+            clear();
+        }
+    }
+}

--- a/src/test/java/com/gloddy/server/service/myGroup/GetRejectedGroupTest.java
+++ b/src/test/java/com/gloddy/server/service/myGroup/GetRejectedGroupTest.java
@@ -1,0 +1,120 @@
+package com.gloddy.server.service.myGroup;
+
+import com.gloddy.server.apply.domain.dto.ApplyRequest;
+import com.gloddy.server.common.myGroup.MyGroupServiceTest;
+import com.gloddy.server.group.domain.dto.GroupRequest;
+import com.gloddy.server.myGroup.read.MyGroupReadService;
+import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Commit;
+import org.springframework.test.context.transaction.AfterTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class GetRejectedGroupTest extends MyGroupServiceTest {
+
+    @Autowired
+    private MyGroupReadService myGroupReadService;
+
+    @Nested
+    class Case1 {
+
+        private Long targetUserId;
+        private Long groupId1;
+        private Long groupId2;
+        private Long applyId1;
+        private Long applyId2;
+
+        @Test
+        @Commit
+        void getAllRejectedGroups_returns_all() {
+            //given
+            Long captainId = createUser();
+            GroupRequest.Create groupCreateCommand1 = createGroupCreateCommand(
+                    LocalDate.now().plusDays(1),
+                    "12:00",
+                    "13:00");
+            GroupRequest.Create groupCreateCommand2 = createGroupCreateCommand(
+                    LocalDate.now().plusDays(2),
+                    "12:00",
+                    "13:00");
+            groupId1 = createGroup(captainId, groupCreateCommand1);
+            groupId2 = createGroup(captainId, groupCreateCommand2);
+
+            Long applierId = createUser();
+            ApplyRequest.Create applyCreateCommand = createApplyCreateCommand();
+            applyId1 = createApply(applierId, groupId1, applyCreateCommand);
+            applyId2 = createApply(applierId, groupId2, applyCreateCommand);
+
+            refuseApply(captainId, applyId1);
+            refuseApply(captainId, applyId2);
+
+            targetUserId = applierId;
+        }
+
+        @AfterTransaction
+        @Transactional
+        @Commit
+        void when_and_then() {
+            //when
+            MyGroupResponse.Rejected rejectedGroups = myGroupReadService.getRejectedGroups(targetUserId);
+
+            //then
+            assertThat(rejectedGroups.getGroups()).hasSize(2);
+            assertThat(rejectedGroups.getGroups().get(0).getApplyId()).isEqualTo(applyId2);
+            assertThat(rejectedGroups.getGroups().get(0).getGroup().getGroupId()).isEqualTo(groupId2);
+            assertThat(rejectedGroups.getGroups().get(1).getApplyId()).isEqualTo(applyId1);
+            assertThat(rejectedGroups.getGroups().get(1).getGroup().getGroupId()).isEqualTo(groupId1);
+
+            //after
+            clear();
+        }
+    }
+
+    @Nested
+    class Case2 {
+
+        private Long targetUserId;
+
+        @Test
+        @Commit
+        void getAllRejectedGroups_returns_empty_list_when_all_refused_check() {
+            //given
+            Long captainId = createUser();
+            GroupRequest.Create groupCreateCommand = createGroupCreateCommand(
+                    LocalDate.now().plusDays(1),
+                    "12:00",
+                    "13:00");
+            Long groupId = createGroup(captainId, groupCreateCommand);
+
+            Long applierId = createUser();
+            ApplyRequest.Create applyCreateCommand = createApplyCreateCommand();
+            Long applyId = createApply(applierId, groupId, applyCreateCommand);
+
+            refuseApply(captainId, applyId);
+
+            checkRejectedApply(applierId, applyId);
+
+            targetUserId = applierId;
+        }
+
+        @AfterTransaction
+        @Transactional
+        @Commit
+        void when_and_then() {
+            //when
+            MyGroupResponse.Rejected rejectedGroups = myGroupReadService.getRejectedGroups(targetUserId);
+
+            //then
+            assertThat(rejectedGroups.getGroups()).isEmpty();
+
+            //after
+            clear();
+        }
+    }
+}

--- a/src/test/java/com/gloddy/server/service/myGroup/GetWaitingGroupTest.java
+++ b/src/test/java/com/gloddy/server/service/myGroup/GetWaitingGroupTest.java
@@ -1,0 +1,72 @@
+package com.gloddy.server.service.myGroup;
+
+import com.gloddy.server.apply.domain.dto.ApplyRequest;
+import com.gloddy.server.common.myGroup.MyGroupServiceTest;
+import com.gloddy.server.group.domain.dto.GroupRequest;
+import com.gloddy.server.myGroup.read.MyGroupReadService;
+import com.gloddy.server.myGroup.read.dto.MyGroupResponse;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Commit;
+import org.springframework.test.context.transaction.AfterTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class GetWaitingGroupTest extends MyGroupServiceTest {
+
+    @Autowired
+    private MyGroupReadService myGroupReadService;
+
+    @Nested
+    class Case1 {
+
+        private Long targetUserId;
+        private Long groupId1;
+        private Long groupId2;
+
+        @Test
+        @Commit
+        void getWaitingGroups_returns_all() {
+            //given
+            Long captainId = createUser();
+            GroupRequest.Create groupCreateCommand1 = createGroupCreateCommand(
+                    LocalDate.now().plusDays(1),
+                    "12:00",
+                    "13:00");
+            GroupRequest.Create groupCreateCommand2 = createGroupCreateCommand(
+                    LocalDate.now().plusDays(1),
+                    "12:00",
+                    "13:00");
+            groupId1 = createGroup(captainId, groupCreateCommand1);
+            groupId2 = createGroup(captainId, groupCreateCommand2);
+
+            Long applierId = createUser();
+            ApplyRequest.Create applyCreateCommand = createApplyCreateCommand();
+            createApply(applierId, groupId1, applyCreateCommand);
+            createApply(applierId, groupId2, applyCreateCommand);
+
+            targetUserId = applierId;
+        }
+
+        @AfterTransaction
+        @Transactional
+        @Commit
+        void when_and_then() {
+            //when
+            MyGroupResponse.Waiting waitingGroups = myGroupReadService.getWaitingGroups(targetUserId);
+
+            //then
+            assertThat(waitingGroups.getGroups()).hasSize(2);
+            assertThat(waitingGroups.getGroups().get(0).getGroup().getGroupId()).isEqualTo(groupId2);
+            assertThat(waitingGroups.getGroups().get(1).getGroup().getGroupId()).isEqualTo(groupId1);
+
+            //after
+            clear();
+        }
+    }
+
+}


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #0
### 작업 사항
- **Participating**, **Hosting**, **Waiting**, **Rejected**, **NotEstimated** 인 나의 모임 조회 API를 구현하였습니다.
- 다들 각각 5개의 endPoint를 파서 구현하였습니다.
  - 이후 각각 활용할 점이 있다고 판단하였습니다.
- Query에 직접 요구사항을 녹여 짤 수 있었으나, **비즈니스 요구사항의 보존**을 위해 `DomainService`에서 직접 객체를 걸러 냈습니다.
   - 사실 이게 맞는 방법인지는 모르겠습니다. 만약 한번에 불러오는 **객체가 많아 질 경우 상당한 양의 stream 과정을 거치기 때문에 성능이 문제가 될지도....**
   - 하지만 **요구사항을 Query에 담기에는 비즈니스 요구사항이 관리가 안될 것 같고...** 애매하네요
- **Group과 User의 의존성을 완전히 분리** 하는게 좋을 것 같습니당...(Group과 User는 포렌키로 엮지말고 id씩 들고 있도록...)
   - 테스트 코드 짤 때도 의존이 많이 되서 given코드가 방대해지고, id로만 가능한 로직이 많은데 참조를 거쳐야되고...
- 또한 **안정성**을 높여야할 것 같습니다.
   - 예를들어 현재 그룹을 생성할 때 그룹 모임 시간이 현재 시간보다 이전 시간으로 생성을 해도 생성이 된다는 그런 상황이 발생...!