### PR TITLE
[CHORE]: CD workflow 구축 (Amazon ECS)

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -1,0 +1,70 @@
+{
+  "taskDefinitionArn": "arn:aws:ecs:ap-northeast-2:750773866215:task-definition/gloddy-prd-spring-task-test:7",
+  "containerDefinitions": [
+    {
+      "name": "springboot",
+      "image": "750773866215.dkr.ecr.ap-northeast-2.amazonaws.com/gloddy-prd:latest",
+      "cpu": 0,
+      "portMappings": [
+        {
+          "name": "springboot-8080-tcp",
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "essential": true,
+      "environment": [],
+      "environmentFiles": [
+        {
+          "value": "arn:aws:s3:::gloddy-env/env/gloddy.env",
+          "type": "s3"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "ulimits": []
+    }
+  ],
+  "family": "gloddy-prd-spring-task-test",
+  "executionRoleArn": "arn:aws:iam::750773866215:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "revision": 7,
+  "volumes": [],
+  "status": "ACTIVE",
+  "requiresAttributes": [
+    {
+      "name": "com.amazonaws.ecs.capability.ecr-auth"
+    },
+    {
+      "name": "ecs.capability.env-files.s3"
+    },
+    {
+      "name": "ecs.capability.execution-role-ecr-pull"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+    },
+    {
+      "name": "ecs.capability.task-eni"
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "EC2",
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "1024",
+  "memory": "3072",
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "registeredAt": "2023-09-13T15:12:56.673Z",
+  "registeredBy": "arn:aws:iam::750773866215:root",
+  "tags": []
+}

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -2,9 +2,7 @@ name: Build Test
 
 on:
   pull_request:
-    branches: [dev]
-  push:
-    branches: [dev]
+    branches: [ "dev" ]
 
 jobs:
   build:

--- a/.github/workflows/DeployOnPRD.yml
+++ b/.github/workflows/DeployOnPRD.yml
@@ -1,0 +1,85 @@
+name: Deploy on PRD Server (Amazon ECS)
+
+on:
+  push:
+    branches: [ "release" ]
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: gloddy-prd
+  ECS_SERVICE: gloddy-prd-ecs-service
+  ECS_CLUSTER: gloddy-ecs-prd
+  ECS_TASK_DEFINITION: .aws/task-definition.json
+
+  CONTAINER_NAME: springboot
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x ./gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew build
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ECS_ACCESS }}
+        aws-secret-access-key: ${{ secrets.AWS_ECS_SECRET }}
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: latest
+      run: |
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+    - name: Fill in the new image ID in the Amazon ECS task definition
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: ${{ env.ECS_TASK_DEFINITION }}
+        container-name: ${{ env.CONTAINER_NAME }}
+        image: ${{ steps.build-image.outputs.image }}
+
+    - name: Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: ${{ env.ECS_SERVICE }}
+        cluster: ${{ env.ECS_CLUSTER }}
+        wait-for-service-stability: true

--- a/.github/workflows/DeployOnPRD.yml
+++ b/.github/workflows/DeployOnPRD.yml
@@ -64,7 +64,7 @@ jobs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         IMAGE_TAG: latest
       run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker build -f Dockerfile_prd -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/DeployOnSTG.yml
+++ b/.github/workflows/DeployOnSTG.yml
@@ -1,9 +1,8 @@
 name: Deploy on STG Server
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [dev]
+  push:
+    branches: [ "dev" ]
 
 jobs:
   build:

--- a/Dockerfile_prd
+++ b/Dockerfile_prd
@@ -1,0 +1,11 @@
+FROM openjdk:17.0-slim
+
+EXPOSE 8080
+
+ARG PROJECT_DIRECTORY=/build
+WORKDIR %PROJECT_DIRECTORY
+
+ARG JAR_FILE_PATH=build/libs/server-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE_PATH} app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## 작업 사항
* Release 서버 CD Gihtub action workflow 구축
* BuildTest Action event trigger 수정
  * 기존에는 pr 생성 시, dev 브랜치에 push 시 action이 돌아가 CI를 실행했다.
  * 서버에 배포할 때 gradle build가 2번 실행되어 배포 시간이 오래걸림 (BuildeTest/DeployOnSTG Action)
  * 따라서 pr 생성 시에만 BuildTest action이 실행되도록 trigger 수정
* DeployOnSTG Action event trigger 수정
  * 기존에는 dev 브랜치의 pr이 닫히면 action이 돌아가 CD를 실행했다.
  * 이 경우, dev 브랜치에 머지되지 않고, pr만 닫은 경우에도 CD가 실행될 것이다.
  * 따라서, dev 브랜치에 push된 경우에만 action이 실행되도록 trigger 수정
