### PR TITLE
[CHORE]: Datadog 설정 (ECS)

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -1,10 +1,11 @@
 {
-  "taskDefinitionArn": "arn:aws:ecs:ap-northeast-2:750773866215:task-definition/gloddy-prd-spring-task-test:7",
+  "taskDefinitionArn": "arn:aws:ecs:ap-northeast-2:750773866215:task-definition/gloddy-prd-spring-task-test:18",
   "containerDefinitions": [
     {
       "name": "springboot",
       "image": "750773866215.dkr.ecr.ap-northeast-2.amazonaws.com/gloddy-prd:latest",
-      "cpu": 0,
+      "cpu": 768,
+      "memory": 1024,
       "portMappings": [
         {
           "name": "springboot-8080-tcp",
@@ -24,18 +25,60 @@
       ],
       "mountPoints": [],
       "volumesFrom": [],
-      "ulimits": []
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-create-group": "true",
+          "awslogs-group": "/ecs/gloddy-prd-spring-task",
+          "awslogs-region": "ap-northeast-2",
+          "awslogs-stream-prefix": "ecs"
+        },
+        "secretOptions": []
+      }
+    },
+    {
+      "name": "datadog-agent",
+      "image": "public.ecr.aws/datadog/agent:latest",
+      "cpu": 203,
+      "memory": 512,
+      "portMappings": [
+        {
+          "name": "datadog-agent-8126-tcp",
+          "containerPort": 8126,
+          "hostPort": 8126,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": false,
+      "environment": [],
+      "environmentFiles": [
+        {
+          "value": "arn:aws:s3:::gloddy-env/env/datadog.env",
+          "type": "s3"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": []
     }
   ],
   "family": "gloddy-prd-spring-task-test",
   "executionRoleArn": "arn:aws:iam::750773866215:role/ecsTaskExecutionRole",
   "networkMode": "awsvpc",
-  "revision": 7,
+  "revision": 18,
   "volumes": [],
   "status": "ACTIVE",
   "requiresAttributes": [
     {
+      "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+    },
+    {
+      "name": "ecs.capability.execution-role-awslogs"
+    },
+    {
       "name": "com.amazonaws.ecs.capability.ecr-auth"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
     },
     {
       "name": "ecs.capability.env-files.s3"
@@ -48,6 +91,9 @@
     },
     {
       "name": "ecs.capability.task-eni"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.29"
     }
   ],
   "placementConstraints": [],
@@ -59,12 +105,12 @@
     "FARGATE"
   ],
   "cpu": "1024",
-  "memory": "3072",
+  "memory": "2048",
   "runtimePlatform": {
     "cpuArchitecture": "X86_64",
     "operatingSystemFamily": "LINUX"
   },
-  "registeredAt": "2023-09-13T15:12:56.673Z",
+  "registeredAt": "2023-10-16T07:41:48.083Z",
   "registeredBy": "arn:aws:iam::750773866215:root",
   "tags": []
 }

--- a/Dockerfile_prd
+++ b/Dockerfile_prd
@@ -8,4 +8,9 @@ WORKDIR %PROJECT_DIRECTORY
 ARG JAR_FILE_PATH=build/libs/server-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE_PATH} app.jar
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+RUN  apt-get update \
+  && apt-get install -y wget \
+  && rm -rf /var/lib/apt/lists/*
+RUN wget -O dd-java-agent.jar https://dtdg.co/latest-java-tracer
+
+ENTRYPOINT ["java", "-javaagent:dd-java-agent.jar", "-XX:FlightRecorderOptions=stackdepth=256", "-Ddd.appsec.enabled=true", "-Ddd.iast.enabled=true", "-Ddd.logs.injection=true", "-Ddd.service=gloddy", "-Ddd.env=production", "-jar", "app.jar"]


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #0
### 작업 사항
- 운영환경 모니터링을 위해 Datadog를 구축하였습니다.
  - ECS Datadog Agent 컨테이너 생성
  - Dockerfile 변경
     - java-tracer 설치
     - jar파일 실행 시 dd 환경변수 추가
### 참고 공식 문서
- [Amazon ECS on AWS Fargate](https://docs.datadoghq.com/ko/integrations/ecs_fargate/?tab=webui#trace-collection).
- [ECS 애플리케이션 추적](https://docs.datadoghq.com/ko/containers/amazon_ecs/apm/?tab=ecs%EC%BB%A8%ED%85%8C%EC%9D%B4%EB%84%88%EB%A9%94%ED%83%80%EB%8D%B0%EC%9D%B4%ED%84%B0%ED%8C%8C%EC%9D%BC).
- [Tracing Java Application](https://docs.datadoghq.com/ko/tracing/trace_collection/dd_libraries/java/?tab=springboot).
