### PR TITLE
[FEAT]: 기존 서버 Adapter 구현 및 AWS SNS Publisher 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,8 @@ dependencies {
 
 	//AWS
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.0")
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-sns'
 
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'

--- a/src/main/java/com/gloddy/server/apply/application/ApplyService.java
+++ b/src/main/java/com/gloddy/server/apply/application/ApplyService.java
@@ -7,6 +7,7 @@ import com.gloddy.server.apply.domain.handler.ApplyCommandHandler;
 import com.gloddy.server.apply.domain.handler.ApplyQueryHandler;
 import com.gloddy.server.apply.domain.service.*;
 import com.gloddy.server.apply.domain.vo.Status;
+import com.gloddy.server.apply.event.ApplyCreateEvent;
 import com.gloddy.server.apply.event.producer.ApplyEventProducer;
 import com.gloddy.server.auth.domain.User;
 import com.gloddy.server.core.event.GroupParticipateEvent;
@@ -30,6 +31,7 @@ public class ApplyService {
     private final GroupQueryHandler groupQueryHandler;
     private final RejectedApplyCheckExecutor rejectedApplyCheckExecutor;
     private final ApplyStatusUpdateExecutor applyStatusUpdateExecutor;
+    private final ApplyEventProducer applyEventProducer;
 
     @Transactional
     public ApplyResponse.Create createApply(Long userId, Long groupId, ApplyRequest.Create request) {
@@ -38,6 +40,7 @@ public class ApplyService {
         Apply apply = applyCommandHandler.save(
                 group.createApply(user, request.getIntroduce(), request.getReason())
         );
+        applyEventProducer.produceEvent(new ApplyCreateEvent(userId, groupId, apply.getId()));
         return new ApplyResponse.Create(apply.getId());
     }
 

--- a/src/main/java/com/gloddy/server/apply/domain/service/ApplyStatusUpdateExecutor.java
+++ b/src/main/java/com/gloddy/server/apply/domain/service/ApplyStatusUpdateExecutor.java
@@ -3,9 +3,12 @@ package com.gloddy.server.apply.domain.service;
 import com.gloddy.server.apply.domain.Apply;
 import com.gloddy.server.apply.domain.handler.ApplyQueryHandler;
 import com.gloddy.server.apply.domain.vo.Status;
+import com.gloddy.server.apply.event.ApplyStatusUpdateEvent;
 import com.gloddy.server.apply.event.producer.ApplyEventProducer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import static com.gloddy.server.apply.domain.vo.Status.*;
 
 @Component
 @RequiredArgsConstructor
@@ -27,5 +30,7 @@ public class ApplyStatusUpdateExecutor {
         } else {
             throw new RuntimeException("Apply Status Invalid");
         }
+
+        applyEventProducer.produceEvent(new ApplyStatusUpdateEvent(userId, apply.getGroup().getId(), applyId, status));
     }
 }

--- a/src/main/java/com/gloddy/server/apply/event/ApplyCreateEvent.java
+++ b/src/main/java/com/gloddy/server/apply/event/ApplyCreateEvent.java
@@ -1,0 +1,16 @@
+package com.gloddy.server.apply.event;
+
+import com.gloddy.server.core.event.Event;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class ApplyCreateEvent implements Event {
+    private Long userId;
+    private Long groupId;
+    private Long applyId;
+}

--- a/src/main/java/com/gloddy/server/apply/event/ApplyStatusUpdateEvent.java
+++ b/src/main/java/com/gloddy/server/apply/event/ApplyStatusUpdateEvent.java
@@ -1,0 +1,18 @@
+package com.gloddy.server.apply.event;
+
+import com.gloddy.server.apply.domain.vo.Status;
+import com.gloddy.server.core.event.Event;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ApplyStatusUpdateEvent implements Event {
+    private Long userId;
+    private Long groupId;
+    private Long applyId;
+    private Status status;
+}

--- a/src/main/java/com/gloddy/server/group_member/application/GroupMemberDeleteService.java
+++ b/src/main/java/com/gloddy/server/group_member/application/GroupMemberDeleteService.java
@@ -28,7 +28,7 @@ public class GroupMemberDeleteService {
         deleteGroupMemberVo(userId, groupId);
         deleteGroupMember(userId, groupId);
 
-        groupMemberEventProducer.produceEvent(new GroupMemberLeaveEvent(userId));
+        groupMemberEventProducer.produceEvent(new GroupMemberLeaveEvent(userId, groupId));
     }
 
     private void deleteGroupMemberVo(Long userId, Long groupId) {

--- a/src/main/java/com/gloddy/server/group_member/event/GroupMemberLeaveEvent.java
+++ b/src/main/java/com/gloddy/server/group_member/event/GroupMemberLeaveEvent.java
@@ -11,4 +11,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupMemberLeaveEvent implements Event {
     private Long userId;
+    private Long groupId;
 }

--- a/src/main/java/com/gloddy/server/messaging/AdapterEvent.java
+++ b/src/main/java/com/gloddy/server/messaging/AdapterEvent.java
@@ -1,0 +1,4 @@
+package com.gloddy.server.messaging;
+
+public interface AdapterEvent {
+}

--- a/src/main/java/com/gloddy/server/messaging/MessagePublisher.java
+++ b/src/main/java/com/gloddy/server/messaging/MessagePublisher.java
@@ -1,0 +1,9 @@
+package com.gloddy.server.messaging;
+
+import com.gloddy.server.messaging.adapter.apply.event.ApplyAdapterEvent;
+import com.gloddy.server.messaging.adapter.group.event.GroupMemberAdapterEvent;
+
+public interface MessagePublisher {
+    void publishApplyEvent(ApplyAdapterEvent event);
+    void publishGroupMemberEvent(GroupMemberAdapterEvent event);
+}

--- a/src/main/java/com/gloddy/server/messaging/adapter/apply/event/ApplyAdapterEvent.java
+++ b/src/main/java/com/gloddy/server/messaging/adapter/apply/event/ApplyAdapterEvent.java
@@ -1,0 +1,17 @@
+package com.gloddy.server.messaging.adapter.apply.event;
+
+import com.gloddy.server.messaging.AdapterEvent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class ApplyAdapterEvent implements AdapterEvent {
+    private Long userId;
+    private Long groupId;
+    private Long applyId;
+    private ApplyEventType eventType;
+}

--- a/src/main/java/com/gloddy/server/messaging/adapter/apply/event/ApplyEventType.java
+++ b/src/main/java/com/gloddy/server/messaging/adapter/apply/event/ApplyEventType.java
@@ -1,0 +1,14 @@
+package com.gloddy.server.messaging.adapter.apply.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ApplyEventType {
+    APPLY_CREATE("지원서가 생성 되었을 때"),
+    APPLY_APPROVE("지원서가 승인 처리 되었을 때"),
+    APPLY_REFUSE("지원서가 거절 처리 되었을 때");
+
+    private final String description;
+}

--- a/src/main/java/com/gloddy/server/messaging/adapter/apply/handler/ApplyAdapterEventHandler.java
+++ b/src/main/java/com/gloddy/server/messaging/adapter/apply/handler/ApplyAdapterEventHandler.java
@@ -1,0 +1,30 @@
+package com.gloddy.server.messaging.adapter.apply.handler;
+
+import com.gloddy.server.apply.event.ApplyCreateEvent;
+import com.gloddy.server.apply.event.ApplyStatusUpdateEvent;
+import com.gloddy.server.messaging.MessagePublisher;
+import com.gloddy.server.messaging.adapter.apply.event.ApplyAdapterEvent;
+import com.gloddy.server.messaging.adapter.apply.mapper.ApplyEventMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ApplyAdapterEventHandler {
+
+    private final MessagePublisher messagePublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ApplyCreateEvent event) {
+        ApplyAdapterEvent adapterEvent = ApplyEventMapper.mapToApplyAdapterEventFrom(event);
+        messagePublisher.publishApplyEvent(adapterEvent);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ApplyStatusUpdateEvent event) {
+        ApplyAdapterEvent adapterEvent = ApplyEventMapper.mapToApplyAdapterEventFrom(event);
+        messagePublisher.publishApplyEvent(adapterEvent);
+    }
+}

--- a/src/main/java/com/gloddy/server/messaging/adapter/apply/mapper/ApplyEventMapper.java
+++ b/src/main/java/com/gloddy/server/messaging/adapter/apply/mapper/ApplyEventMapper.java
@@ -1,0 +1,38 @@
+package com.gloddy.server.messaging.adapter.apply.mapper;
+
+import com.gloddy.server.apply.domain.vo.Status;
+import com.gloddy.server.apply.event.ApplyCreateEvent;
+import com.gloddy.server.apply.event.ApplyStatusUpdateEvent;
+import com.gloddy.server.messaging.adapter.apply.event.ApplyAdapterEvent;
+import com.gloddy.server.messaging.adapter.apply.event.ApplyEventType;
+
+public class ApplyEventMapper {
+
+    public static ApplyAdapterEvent mapToApplyAdapterEventFrom(ApplyCreateEvent applyCreateEvent) {
+        return new ApplyAdapterEvent(
+                applyCreateEvent.getUserId(),
+                applyCreateEvent.getGroupId(),
+                applyCreateEvent.getApplyId(),
+                ApplyEventType.APPLY_CREATE
+        );
+    }
+
+    public static ApplyAdapterEvent mapToApplyAdapterEventFrom(ApplyStatusUpdateEvent applyStatusUpdateEvent) {
+        return new ApplyAdapterEvent(
+                applyStatusUpdateEvent.getUserId(),
+                applyStatusUpdateEvent.getGroupId(),
+                applyStatusUpdateEvent.getApplyId(),
+                getApplyEventType(applyStatusUpdateEvent.getStatus())
+        );
+    }
+
+    private static ApplyEventType getApplyEventType(Status status) {
+        if (status.isApprove()) {
+            return ApplyEventType.APPLY_APPROVE;
+        } else if (status.isRefuse()) {
+            return ApplyEventType.APPLY_REFUSE;
+        } else {
+            throw new RuntimeException("invalid apply status");
+        }
+    }
+}

--- a/src/main/java/com/gloddy/server/messaging/adapter/group/event/GroupMemberAdapterEvent.java
+++ b/src/main/java/com/gloddy/server/messaging/adapter/group/event/GroupMemberAdapterEvent.java
@@ -1,0 +1,16 @@
+package com.gloddy.server.messaging.adapter.group.event;
+
+import com.gloddy.server.messaging.AdapterEvent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class GroupMemberAdapterEvent implements AdapterEvent {
+    private Long userId;
+    private Long groupId;
+    private GroupMemberEventType eventType;
+}

--- a/src/main/java/com/gloddy/server/messaging/adapter/group/event/GroupMemberEventType.java
+++ b/src/main/java/com/gloddy/server/messaging/adapter/group/event/GroupMemberEventType.java
@@ -1,0 +1,12 @@
+package com.gloddy.server.messaging.adapter.group.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum GroupMemberEventType {
+    GROUP_MEMBER_LEAVE("그룹 멤버가 모임을 나갔을 때");
+
+    private final String description;
+}

--- a/src/main/java/com/gloddy/server/messaging/adapter/group/handler/GroupMemberAdapterEventHandler.java
+++ b/src/main/java/com/gloddy/server/messaging/adapter/group/handler/GroupMemberAdapterEventHandler.java
@@ -1,0 +1,26 @@
+package com.gloddy.server.messaging.adapter.group.handler;
+
+import com.gloddy.server.group_member.event.GroupMemberLeaveEvent;
+import com.gloddy.server.messaging.MessagePublisher;
+import com.gloddy.server.messaging.adapter.group.event.GroupMemberAdapterEvent;
+import com.gloddy.server.messaging.adapter.group.event.GroupMemberEventType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class GroupMemberAdapterEventHandler {
+    private final MessagePublisher messagePublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(GroupMemberLeaveEvent event) {
+        GroupMemberAdapterEvent adapterEvent = new GroupMemberAdapterEvent(
+                event.getUserId(),
+                event.getGroupId(),
+                GroupMemberEventType.GROUP_MEMBER_LEAVE);
+
+        messagePublisher.publishGroupMemberEvent(adapterEvent);
+    }
+}

--- a/src/main/java/com/gloddy/server/messaging/sns/config/SnsConfig.java
+++ b/src/main/java/com/gloddy/server/messaging/sns/config/SnsConfig.java
@@ -1,0 +1,18 @@
+package com.gloddy.server.messaging.sns.config;
+
+import io.awspring.cloud.sns.core.TopicArnResolver;
+import io.awspring.cloud.sns.core.TopicsListingTopicArnResolver;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.sns.SnsClient;
+
+@Configuration
+@EnableConfigurationProperties(SnsProperties.class)
+public class SnsConfig {
+
+    @Bean
+    public TopicArnResolver topicArnResolver(SnsClient snsClient) {
+        return new TopicsListingTopicArnResolver(snsClient);
+    }
+}

--- a/src/main/java/com/gloddy/server/messaging/sns/config/SnsProperties.java
+++ b/src/main/java/com/gloddy/server/messaging/sns/config/SnsProperties.java
@@ -1,0 +1,13 @@
+package com.gloddy.server.messaging.sns.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spring.cloud.event")
+@Getter
+@Setter
+public class SnsProperties {
+    private String applyTopic;
+    private String groupMemberTopic;
+}

--- a/src/main/java/com/gloddy/server/messaging/sns/publisher/SnsPublisher.java
+++ b/src/main/java/com/gloddy/server/messaging/sns/publisher/SnsPublisher.java
@@ -1,0 +1,41 @@
+package com.gloddy.server.messaging.sns.publisher;
+
+import com.gloddy.server.messaging.AdapterEvent;
+import com.gloddy.server.messaging.MessagePublisher;
+import com.gloddy.server.messaging.adapter.apply.event.ApplyAdapterEvent;
+import com.gloddy.server.messaging.adapter.group.event.GroupMemberAdapterEvent;
+import com.gloddy.server.messaging.sns.config.SnsProperties;
+import io.awspring.cloud.sns.core.SnsTemplate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class SnsPublisher implements MessagePublisher {
+
+    private final SnsProperties snsProperties;
+    private final SnsTemplate snsTemplate;
+
+    @Override
+    public void publishApplyEvent(ApplyAdapterEvent event) {
+        send(snsProperties.getApplyTopic(), event, null);
+    }
+
+    @Override
+    public void publishGroupMemberEvent(GroupMemberAdapterEvent event) {
+        send(snsProperties.getGroupMemberTopic(), event, null);
+    }
+
+    private void send(String topicName, AdapterEvent event, @Nullable String subject) {
+        log.info("이벤트 발행 시작(AWS SNS)");
+        try {
+            snsTemplate.sendNotification(topicName, event, subject);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        log.info("이벤트 발행 완료(AWS SNS)");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,17 @@ spring:
       max-file-size: ${MAX_FILE_SIZE}
       max-request-size: ${MAX_REQUEST_SIZE}
 
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}
+        secret-key: ${AWS_SECRET_KEY}
+      region:
+        static: ap-northeast-2
+    event:
+      apply-topic: ${APPLY_TOPIC}
+      group-member-topic: ${GROUP_MEMBER_TOPIC}
+
 logging:
   level:
     com.gloddy.server.authSms.infra: debug
@@ -79,4 +90,3 @@ springdoc:
   swagger-ui:
     url: /v3/api-docs
     urls-primary-name: Gloddy
-

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -31,6 +31,17 @@ spring:
     pathmatch:
       matching-strategy: ant_path_matcher
 
+  cloud:
+    aws:
+      credentials:
+        access-key: dummy-key
+        secret-key: dummy-key
+      region:
+        static: ap-northeast-2
+    event:
+      apply-topic: dummy-apply-topic
+      group-member-topic: dummy-group-member-topic
+
 jwt:
   header: X-AUTH-TOKEN
   secret: testJwtSecret-testJwtSecret-testJwtSecret-testJwtSecret-testJwtSecret-testJwtSecret


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #0
### 작업 사항
#### Adapter 구현
**구현한 이유**
1. **기존 레거시 코드들**과 **추가되는 기능 및 서버**와 **서로 관계**가 있음(ex. 지원서가 승인 되면 알림을 저장한다.) 
 -> 따라서 **기존 레거시 서버와 새로 추가되는 서버와 통합**이 필요한데 기존 레거시 서버의 모델들(ex. 이벤트 모델)이 공통적으로 사용할 수 없는 모델임(공통된 이벤트 모델이 아니라 기존의 개발을 위해 짜여져서 기존 모델을 새로운 서버가 사용못하는 문제가 발생)
-> 따라서 두 모델을 통합하기 위해 모델을 맞춰야 하는 기능이 필요한데 그 기능을 Adapter가 할 수 있도록 구현하였습니다. 

#### AWS SNS 구축
- [Spring Cloud AWS 3.0.0 버전 사용](https://docs.awspring.io/spring-cloud-aws/docs/3.0.0/reference/html/index.html#spring-cloud-aws-sns)
- AWS Sns Publisher 구현

#### 추가된 ENV
- APPLY_TOPIC
- GROUP_MEMBER_TOPIC
