### PR TITLE
[FIX]: 지원서 생성 시 이벤트에 CaptainId 넘겨주도록 수정

### DIFF
--- a/src/main/java/com/gloddy/server/apply/application/ApplyService.java
+++ b/src/main/java/com/gloddy/server/apply/application/ApplyService.java
@@ -40,7 +40,7 @@ public class ApplyService {
         Apply apply = applyCommandHandler.save(
                 group.createApply(user, request.getIntroduce(), request.getReason())
         );
-        applyEventProducer.produceEvent(new ApplyCreateEvent(userId, groupId));
+        applyEventProducer.produceEvent(new ApplyCreateEvent(group.getCaptainId(), groupId, userId));
         return new ApplyResponse.Create(apply.getId());
     }
 

--- a/src/main/java/com/gloddy/server/apply/event/ApplyCreateEvent.java
+++ b/src/main/java/com/gloddy/server/apply/event/ApplyCreateEvent.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 public class ApplyCreateEvent implements Event {
-    private Long userId;
+    private Long captainId;
     private Long groupId;
+    private Long applyUserId;
 }

--- a/src/main/java/com/gloddy/server/apply/event/ApplyStatusUpdateEvent.java
+++ b/src/main/java/com/gloddy/server/apply/event/ApplyStatusUpdateEvent.java
@@ -11,8 +11,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class ApplyStatusUpdateEvent implements Event {
-    private Long userId;
-    private Long applyGroupId;
+    private Long captainId;
+    private Long groupId;
     private Long applyUserId;
     private Status status;
 }

--- a/src/main/java/com/gloddy/server/group/domain/Group.java
+++ b/src/main/java/com/gloddy/server/group/domain/Group.java
@@ -98,6 +98,10 @@ public class Group extends BaseTimeEntity {
         return this.groupMemberVOs.getSize();
     }
 
+    public Long getCaptainId() {
+        return this.captain.getId();
+    }
+
     public Apply createApply(User applier, String introduce, String reason) {
         return Apply.builder()
                 .user(applier)

--- a/src/main/java/com/gloddy/server/messaging/adapter/apply/mapper/ApplyEventMapper.java
+++ b/src/main/java/com/gloddy/server/messaging/adapter/apply/mapper/ApplyEventMapper.java
@@ -10,17 +10,17 @@ public class ApplyEventMapper {
 
     public static ApplyAdapterEvent mapToApplyAdapterEventFrom(ApplyCreateEvent applyCreateEvent) {
         return new ApplyAdapterEvent(
-                applyCreateEvent.getUserId(),
+                applyCreateEvent.getCaptainId(),
                 applyCreateEvent.getGroupId(),
-                applyCreateEvent.getUserId(),
+                applyCreateEvent.getApplyUserId(),
                 ApplyEventType.APPLY_CREATE
         );
     }
 
     public static ApplyAdapterEvent mapToApplyAdapterEventFrom(ApplyStatusUpdateEvent applyStatusUpdateEvent) {
         return new ApplyAdapterEvent(
-                applyStatusUpdateEvent.getUserId(),
-                applyStatusUpdateEvent.getApplyGroupId(),
+                applyStatusUpdateEvent.getCaptainId(),
+                applyStatusUpdateEvent.getGroupId(),
                 applyStatusUpdateEvent.getApplyUserId(),
                 getApplyEventType(applyStatusUpdateEvent.getStatus())
         );


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #126 
### 작업 사항
* 기존에는 captainId, applyUserId 모두 지원서를 작성한 userId를 넘겨주도록 되어 있어 수정했습니다.