### PR TITLE
[FIX]: Internal EventType 역직렬화 문제 해결

### DIFF
--- a/src/main/java/com/gloddy/server/article/api/in/ArticlePayloadApi.java
+++ b/src/main/java/com/gloddy/server/article/api/in/ArticlePayloadApi.java
@@ -2,6 +2,7 @@ package com.gloddy.server.article.api.in;
 
 import com.gloddy.server.article.application.ArticlePayloadService;
 import com.gloddy.server.article.domain.dto.ArticlePayload;
+import com.gloddy.server.article.domain.dto.in.GroupArticlePayloadEventType;
 import com.gloddy.server.core.response.ApiResponse;
 import com.gloddy.server.messaging.adapter.group.event.GroupArticleEventType;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,7 @@ public class ArticlePayloadApi {
     @GetMapping("/groups/articles/{articleId}")
     public ResponseEntity<ArticlePayload> getArticlePayload(
             @PathVariable("articleId") Long articleId,
-            @RequestParam("eventType") GroupArticleEventType eventType
+            @RequestParam("eventType") GroupArticlePayloadEventType eventType
     ) {
         ArticlePayload response = articlePayloadService.getArticlePayload(articleId, eventType);
         return ApiResponse.ok(response);

--- a/src/main/java/com/gloddy/server/article/application/ArticlePayloadService.java
+++ b/src/main/java/com/gloddy/server/article/application/ArticlePayloadService.java
@@ -2,6 +2,7 @@ package com.gloddy.server.article.application;
 
 import com.gloddy.server.article.domain.Article;
 import com.gloddy.server.article.domain.dto.ArticlePayload;
+import com.gloddy.server.article.domain.dto.in.GroupArticlePayloadEventType;
 import com.gloddy.server.article.domain.handler.ArticleQueryHandler;
 import com.gloddy.server.messaging.adapter.group.event.GroupArticleEventType;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +13,7 @@ import org.springframework.stereotype.Service;
 public class ArticlePayloadService {
     private final ArticleQueryHandler articleQueryHandler;
 
-    public ArticlePayload getArticlePayload(Long articleId, GroupArticleEventType eventType) {
+    public ArticlePayload getArticlePayload(Long articleId, GroupArticlePayloadEventType eventType) {
         Article article = articleQueryHandler.findByIdFetchUserAndGroup(articleId);
 
         return ArticlePayload.toDto(article);

--- a/src/main/java/com/gloddy/server/article/domain/dto/in/GroupArticlePayloadEventType.java
+++ b/src/main/java/com/gloddy/server/article/domain/dto/in/GroupArticlePayloadEventType.java
@@ -1,0 +1,5 @@
+package com.gloddy.server.article.domain.dto.in;
+
+public enum GroupArticlePayloadEventType {
+    GROUP_ARTICLE_CREATE
+}

--- a/src/main/java/com/gloddy/server/group/api/in/GroupPayloadApi.java
+++ b/src/main/java/com/gloddy/server/group/api/in/GroupPayloadApi.java
@@ -4,6 +4,8 @@ import com.gloddy.server.core.response.ApiResponse;
 import com.gloddy.server.group.application.GroupPayloadService;
 import com.gloddy.server.group.domain.dto.GroupMemberPayload;
 import com.gloddy.server.group.domain.dto.GroupPayload;
+import com.gloddy.server.group.domain.vo.in.GroupMemberPayloadEventType;
+import com.gloddy.server.group.domain.vo.in.GroupPayloadEventType;
 import com.gloddy.server.messaging.adapter.group.event.GroupEventType;
 import com.gloddy.server.messaging.adapter.group.event.GroupMemberEventType;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +25,7 @@ public class GroupPayloadApi {
     @GetMapping("/groups/{groupId}")
     public ResponseEntity<GroupPayload> getGroupPayload(
             @PathVariable("groupId") Long groupId,
-            @RequestParam("eventType") GroupEventType eventType
+            @RequestParam("eventType") GroupPayloadEventType eventType
     ) {
         GroupPayload response = groupPayloadService.getGroupPayload(groupId, eventType);
         return ApiResponse.ok(response);
@@ -32,7 +34,7 @@ public class GroupPayloadApi {
     @GetMapping("/groups/members/{groupMemberId}")
     public ResponseEntity<GroupMemberPayload> getGroupPayload(
             @PathVariable("groupMemberId") Long groupMemberId,
-            @RequestParam("eventType") GroupMemberEventType eventType
+            @RequestParam("eventType") GroupMemberPayloadEventType eventType
     ) {
         GroupMemberPayload response = groupPayloadService.getGroupMemberPayload(groupMemberId, eventType);
         return ApiResponse.ok(response);

--- a/src/main/java/com/gloddy/server/group/application/GroupPayloadService.java
+++ b/src/main/java/com/gloddy/server/group/application/GroupPayloadService.java
@@ -4,6 +4,8 @@ import com.gloddy.server.group.domain.Group;
 import com.gloddy.server.group.domain.dto.GroupMemberPayload;
 import com.gloddy.server.group.domain.dto.GroupPayload;
 import com.gloddy.server.group.domain.handler.GroupQueryHandler;
+import com.gloddy.server.group.domain.vo.in.GroupMemberPayloadEventType;
+import com.gloddy.server.group.domain.vo.in.GroupPayloadEventType;
 import com.gloddy.server.group_member.domain.GroupMember;
 import com.gloddy.server.group_member.domain.handler.GroupMemberQueryHandler;
 import com.gloddy.server.messaging.adapter.group.event.GroupEventType;
@@ -17,13 +19,13 @@ public class GroupPayloadService {
     private final GroupQueryHandler groupQueryHandler;
     private final GroupMemberQueryHandler groupMemberQueryHandler;
 
-    public GroupPayload getGroupPayload(Long groupId, GroupEventType eventType) {
+    public GroupPayload getGroupPayload(Long groupId, GroupPayloadEventType eventType) {
         Group group = groupQueryHandler.findById(groupId);
 
         return GroupPayload.toDto(group);
     }
 
-    public GroupMemberPayload getGroupMemberPayload(Long groupMemberId, GroupMemberEventType eventType) {
+    public GroupMemberPayload getGroupMemberPayload(Long groupMemberId, GroupMemberPayloadEventType eventType) {
         GroupMember groupMember = groupMemberQueryHandler.findById(groupMemberId);
 
         return GroupMemberPayload.toDto(groupMember);

--- a/src/main/java/com/gloddy/server/group/domain/vo/in/GroupMemberPayloadEventType.java
+++ b/src/main/java/com/gloddy/server/group/domain/vo/in/GroupMemberPayloadEventType.java
@@ -1,0 +1,5 @@
+package com.gloddy.server.group.domain.vo.in;
+
+public enum GroupMemberPayloadEventType {
+    GROUP_LEAVE
+}

--- a/src/main/java/com/gloddy/server/group/domain/vo/in/GroupPayloadEventType.java
+++ b/src/main/java/com/gloddy/server/group/domain/vo/in/GroupPayloadEventType.java
@@ -1,0 +1,6 @@
+package com.gloddy.server.group.domain.vo.in;
+
+public enum GroupPayloadEventType {
+    GROUP_APPROACHING_START,
+    GROUP_END
+}


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #138 
### 작업 사항
## 문제상황
- 알림 서버에서 정의한 domain EventType과 기존 서버에서 정의한 domain EventType이 다름.
-> 알림 서버에서 정의한 domain EventType으로 internal API를 날릴 때 역직렬화 문제가 발생

## 임시 해결
- 우선  시간이 없으니임시로 기존 서버에 알림서버에서 정의한 domain EventType을 정의하고 internal API로 받도록 수정
- 언젠가는 이 이벤트 타입을 통합해야 할 것 같음