### PR TITLE
[FIX]: groupMember leave 이벤트 재설계

### DIFF
--- a/src/main/java/com/gloddy/server/group/api/in/GroupPayloadApi.java
+++ b/src/main/java/com/gloddy/server/group/api/in/GroupPayloadApi.java
@@ -31,12 +31,13 @@ public class GroupPayloadApi {
         return ApiResponse.ok(response);
     }
 
-    @GetMapping("/groups/members/{groupMemberId}")
-    public ResponseEntity<GroupMemberPayload> getGroupPayload(
-            @PathVariable("groupMemberId") Long groupMemberId,
+    @GetMapping("/groups/{groupId}/members/{userId}")
+    public ResponseEntity<GroupMemberPayload> getGroupMemberPayload(
+            @PathVariable("groupId") Long groupId,
+            @PathVariable("userId") Long userId,
             @RequestParam("eventType") GroupMemberPayloadEventType eventType
     ) {
-        GroupMemberPayload response = groupPayloadService.getGroupMemberPayload(groupMemberId, eventType);
+        GroupMemberPayload response = groupPayloadService.getGroupMemberPayload(groupId, userId, eventType);
         return ApiResponse.ok(response);
     }
 }

--- a/src/main/java/com/gloddy/server/group/application/GroupPayloadService.java
+++ b/src/main/java/com/gloddy/server/group/application/GroupPayloadService.java
@@ -6,10 +6,8 @@ import com.gloddy.server.group.domain.dto.GroupPayload;
 import com.gloddy.server.group.domain.handler.GroupQueryHandler;
 import com.gloddy.server.group.domain.vo.in.GroupMemberPayloadEventType;
 import com.gloddy.server.group.domain.vo.in.GroupPayloadEventType;
-import com.gloddy.server.group_member.domain.GroupMember;
-import com.gloddy.server.group_member.domain.handler.GroupMemberQueryHandler;
-import com.gloddy.server.messaging.adapter.group.event.GroupEventType;
-import com.gloddy.server.messaging.adapter.group.event.GroupMemberEventType;
+import com.gloddy.server.user.domain.User;
+import com.gloddy.server.user.domain.handler.UserQueryHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,7 +15,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GroupPayloadService {
     private final GroupQueryHandler groupQueryHandler;
-    private final GroupMemberQueryHandler groupMemberQueryHandler;
+    private final UserQueryHandler userQueryHandler;
 
     public GroupPayload getGroupPayload(Long groupId, GroupPayloadEventType eventType) {
         Group group = groupQueryHandler.findById(groupId);
@@ -25,9 +23,10 @@ public class GroupPayloadService {
         return GroupPayload.toDto(group);
     }
 
-    public GroupMemberPayload getGroupMemberPayload(Long groupMemberId, GroupMemberPayloadEventType eventType) {
-        GroupMember groupMember = groupMemberQueryHandler.findById(groupMemberId);
+    public GroupMemberPayload getGroupMemberPayload(Long groupId, Long userId, GroupMemberPayloadEventType eventType) {
+        Group group = groupQueryHandler.findById(groupId);
+        User groupMemberUser = userQueryHandler.findById(userId);
 
-        return GroupMemberPayload.toDto(groupMember);
+        return GroupMemberPayload.toDto(group, groupMemberUser);
     }
 }

--- a/src/main/java/com/gloddy/server/group/domain/dto/GroupMemberPayload.java
+++ b/src/main/java/com/gloddy/server/group/domain/dto/GroupMemberPayload.java
@@ -1,6 +1,7 @@
 package com.gloddy.server.group.domain.dto;
 
-import com.gloddy.server.group_member.domain.GroupMember;
+import com.gloddy.server.group.domain.Group;
+import com.gloddy.server.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,12 +15,12 @@ public class GroupMemberPayload {
     private String groupMemberName;
     private String groupImage;
 
-    public static GroupMemberPayload toDto(GroupMember groupMember) {
+    public static GroupMemberPayload toDto(Group group, User groupMemberUser) {
         return new GroupMemberPayload(
-                groupMember.getGroup().getId(),
-                groupMember.getGroup().getCaptainId(),
-                groupMember.getUser().getNickName(),
-                groupMember.getGroup().getImageUrl()
+                group.getId(),
+                group.getCaptainId(),
+                groupMemberUser.getNickName(),
+                group.getImageUrl()
         );
     }
 }

--- a/src/main/java/com/gloddy/server/group_member/application/GroupMemberDeleteService.java
+++ b/src/main/java/com/gloddy/server/group_member/application/GroupMemberDeleteService.java
@@ -25,11 +25,10 @@ public class GroupMemberDeleteService {
 
     @Transactional
     public void delete(Long userId, Long groupId) {
-        GroupMember groupMember = groupMemberQueryHandler.findByUserIdAndGroupId(userId, groupId);
         deleteGroupMemberVo(userId, groupId);
         deleteGroupMember(userId, groupId);
 
-        groupMemberEventProducer.produceEvent(new GroupMemberLeaveEvent(groupMember.getId(), userId));
+        groupMemberEventProducer.produceEvent(new GroupMemberLeaveEvent(groupId, userId));
     }
 
     private void deleteGroupMemberVo(Long userId, Long groupId) {

--- a/src/main/java/com/gloddy/server/group_member/event/GroupMemberLeaveEvent.java
+++ b/src/main/java/com/gloddy/server/group_member/event/GroupMemberLeaveEvent.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupMemberLeaveEvent implements Event {
-    private Long groupMemberId;
+    private Long groupId;
     private Long userId;
 }

--- a/src/main/java/com/gloddy/server/messaging/adapter/group/event/GroupMemberAdapterEvent.java
+++ b/src/main/java/com/gloddy/server/messaging/adapter/group/event/GroupMemberAdapterEvent.java
@@ -12,7 +12,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 public class GroupMemberAdapterEvent implements AdapterEvent {
-    private Long groupMemberId;
+    private Long groupId;
+    private Long userId;
     private GroupMemberEventType eventType;
     private LocalDateTime eventDateTime;
 }

--- a/src/main/java/com/gloddy/server/messaging/adapter/group/mapper/GroupEventMapper.java
+++ b/src/main/java/com/gloddy/server/messaging/adapter/group/mapper/GroupEventMapper.java
@@ -20,7 +20,8 @@ public class GroupEventMapper {
 
     public static GroupMemberAdapterEvent mapToGroupMemberAdapterEvent(GroupMemberLeaveEvent event) {
         return new GroupMemberAdapterEvent(
-                event.getGroupMemberId(),
+                event.getGroupId(),
+                event.getUserId(),
                 GroupMemberEventType.GROUP_MEMBER_LEAVE,
                 LocalDateTime.now()
         );


### PR DESCRIPTION
## 작업 사항
* 기존에는 그룹 멤버가 나가는 경우 groupMember 삭제 후 groupMemberId를 담은 groupMember 이벤트를 발행했다.
* 그 후, 알림 서버에서 groupMember의 이름을 가져오기 위해 payload 요청 시 groupMember는 삭제된 상태이기 때문에 조회 불가능
* 따라서, 그룹 멤버가 나가는 경우 groupMember를 삭제하고, groupId, userId를 담은 이벤트를 발행하도록 수정
