### PR TITLE
[Feat]: 국가 정보 데이터 정리 및 유저 프로필에 국가 정보 반영

### DIFF
--- a/src/main/java/com/gloddy/server/auth/api/AuthApi.java
+++ b/src/main/java/com/gloddy/server/auth/api/AuthApi.java
@@ -5,6 +5,7 @@ import com.gloddy.server.auth.domain.dto.AuthRequest;
 import com.gloddy.server.auth.domain.dto.AuthResponse;
 import com.gloddy.server.core.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,7 +28,7 @@ public class AuthApi {
 
     @Operation(security = {})
     @PostMapping("/sign-up")
-    public ResponseEntity<AuthResponse.SignUp> signUp(@RequestBody AuthRequest.SignUp req) {
+    public ResponseEntity<AuthResponse.SignUp> signUp(@RequestBody @Valid AuthRequest.SignUp req) {
         AuthResponse.SignUp response = authService.signUp(req);
 
         return ApiResponse.ok(response);

--- a/src/main/java/com/gloddy/server/auth/domain/dto/AuthRequest.java
+++ b/src/main/java/com/gloddy/server/auth/domain/dto/AuthRequest.java
@@ -3,6 +3,7 @@ package com.gloddy.server.auth.domain.dto;
 import com.gloddy.server.user.domain.vo.kind.Gender;
 import com.gloddy.server.user.domain.vo.kind.Personality;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,6 +30,10 @@ public class AuthRequest {
         private LocalDate birth;
         private Gender gender;
         private List<Personality> personalities;
+        @NotBlank(message = "국적 이름 입력은 필수 입니다.")
+        private String countryName;
+        @NotBlank(message = "국적 이미지 입력은 필수 입니다.")
+        private String countryImage;
 
         @Getter
         @Setter

--- a/src/main/java/com/gloddy/server/auth/domain/service/UserFactory.java
+++ b/src/main/java/com/gloddy/server/auth/domain/service/UserFactory.java
@@ -39,5 +39,4 @@ public class UserFactory {
         }
         return School.createNoCertified(schoolInfo.getSchool());
     }
-
 }

--- a/src/main/java/com/gloddy/server/auth/domain/service/UserProfileFactory.java
+++ b/src/main/java/com/gloddy/server/auth/domain/service/UserProfileFactory.java
@@ -1,5 +1,6 @@
 package com.gloddy.server.auth.domain.service;
 
+import com.gloddy.server.user.domain.vo.Country;
 import com.gloddy.server.user.domain.vo.Profile;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,7 @@ public class UserProfileFactory {
                 .gender(request.getGender())
                 .introduce(null)
                 .personalities(request.getPersonalities())
+                .country(new Country(request.getCountryName(), request.getCountryImage()))
                 .build();
     }
 }

--- a/src/main/java/com/gloddy/server/user/application/UserUpdateService.java
+++ b/src/main/java/com/gloddy/server/user/application/UserUpdateService.java
@@ -24,7 +24,9 @@ public class UserUpdateService {
                 request.getBirth(),
                 request.getGender(),
                 request.getIntroduce(),
-                request.getPersonalities()
+                request.getPersonalities(),
+                request.getCountryName(),
+                request.getCountryImage()
         );
         return UserUpdateResponse.of(user.getProfile());
     }

--- a/src/main/java/com/gloddy/server/user/domain/User.java
+++ b/src/main/java/com/gloddy/server/user/domain/User.java
@@ -1,8 +1,6 @@
 package com.gloddy.server.user.domain;
 
-import com.gloddy.server.user.domain.vo.Profile;
-import com.gloddy.server.user.domain.vo.Phone;
-import com.gloddy.server.user.domain.vo.School;
+import com.gloddy.server.user.domain.vo.*;
 import com.gloddy.server.user.domain.vo.kind.Authority;
 import com.gloddy.server.user.domain.vo.kind.Gender;
 import com.gloddy.server.user.domain.vo.kind.Personality;
@@ -11,17 +9,10 @@ import com.gloddy.server.core.entity.common.BaseTimeEntity;
 import com.gloddy.server.core.event.GroupParticipateEvent;
 import com.gloddy.server.group.event.GroupCreateEvent;
 import com.gloddy.server.group.event.producer.GroupEventProducer;
-import com.gloddy.server.user.domain.Praise;
 import com.gloddy.server.group.domain.Group;
 import com.gloddy.server.group.domain.dto.GroupRequest;
 import com.gloddy.server.group.domain.handler.GroupCommandHandler;
 import com.gloddy.server.group.domain.service.GroupFactory;
-import com.gloddy.server.user.domain.vo.PraiseValue;
-import com.gloddy.server.user.domain.Reliability;
-import com.gloddy.server.user.domain.vo.ReliabilityLevel;
-import com.gloddy.server.user.domain.vo.ScoreMinusType;
-import com.gloddy.server.user.domain.vo.ScorePlusType;
-import com.gloddy.server.user.domain.vo.ScoreTypes;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -123,8 +114,13 @@ public class User extends BaseTimeEntity {
         return this.profile.getPersonalities();
     }
 
+    public Country getCountry() {
+        return this.profile.getCountry();
+    }
+
     public void updateProfile(String imageUrl, String nickname, LocalDate birth,
-                              Gender gender, String introduce, List<Personality> personalities
+                              Gender gender, String introduce, List<Personality> personalities,
+                              String countryName, String countryImage
     ) {
         this.profile = Profile.builder()
                 .imageUrl(imageUrl)
@@ -133,6 +129,7 @@ public class User extends BaseTimeEntity {
                 .gender(gender)
                 .introduce(introduce)
                 .personalities(personalities)
+                .country(new Country(countryName, countryImage))
                 .build();
     }
 

--- a/src/main/java/com/gloddy/server/user/domain/dto/UserResponse.java
+++ b/src/main/java/com/gloddy/server/user/domain/dto/UserResponse.java
@@ -31,6 +31,8 @@ public class UserResponse {
         private String school;
         private String introduce;
         private List<String> personalities;
+        private String countryName;
+        private String countryImage;
         private LocalDate joinAt;
         private ReliabilityLevel reliabilityLevel;
         private Long reliabilityScore;

--- a/src/main/java/com/gloddy/server/user/domain/dto/UserUpdateRequest.java
+++ b/src/main/java/com/gloddy/server/user/domain/dto/UserUpdateRequest.java
@@ -32,5 +32,11 @@ public class UserUpdateRequest {
 
         @Size(min = 3)
         private List<Personality> personalities;
+
+        @NotBlank(message = "국적 이름 입력은 필수 입니다.")
+        private String countryName;
+
+        @NotBlank(message = "국적 이미지 입력은 필수 입니다.")
+        private String countryImage;
     }
 }

--- a/src/main/java/com/gloddy/server/user/domain/dto/UserUpdateResponse.java
+++ b/src/main/java/com/gloddy/server/user/domain/dto/UserUpdateResponse.java
@@ -18,6 +18,8 @@ public class UserUpdateResponse {
     private Gender gender;
     private String introduce;
     private List<Personality> personality;
+    private String countryName;
+    private String countryImage;
 
     public static UserUpdateResponse of(Profile profile) {
         return new UserUpdateResponse(
@@ -26,7 +28,9 @@ public class UserUpdateResponse {
                 profile.getBirth(),
                 profile.getGender(),
                 profile.getIntroduce(),
-                profile.getPersonalities()
+                profile.getPersonalities(),
+                profile.getCountry().getName(),
+                profile.getCountry().getImage()
         );
     }
 }

--- a/src/main/java/com/gloddy/server/user/domain/service/UserDtoMapper.java
+++ b/src/main/java/com/gloddy/server/user/domain/service/UserDtoMapper.java
@@ -8,27 +8,8 @@ import com.gloddy.server.core.utils.TimeUtil;
 import com.gloddy.server.user.domain.Praise;
 import com.gloddy.server.user.domain.Reliability;
 import com.gloddy.server.user.domain.dto.UserResponse;
-import com.gloddy.server.user.domain.dto.UserGetResponse;
 
 public class UserDtoMapper {
-
-    public static UserGetResponse toUserGet(User user, Reliability reliability, Praise praise, int reviewCount) {
-        return new UserGetResponse(
-                user.isCertifiedStudent(),
-                user.getImageUrl(),
-                user.getNickName(),
-                user.getGender().name(),
-                TimeUtil.calculateAge(user.getBirth()),
-                toStringBirth(user),
-                user.getSchool(),
-                reliability.getLevel(),
-                praise.sumPraiseCount(),
-                reviewCount,
-                user.getIntroduce(),
-                Personality.of(user.getPersonalities()),
-                user.getJoinAt()
-        );
-    }
 
     public static UserResponse.FacadeGet toUserGet(User user, Praise praise, Reliability reliability,
                                             Long participatedGroupCount, Long reviewCount) {
@@ -43,6 +24,8 @@ public class UserDtoMapper {
                 user.getSchool(),
                 user.getIntroduce(),
                 Personality.of(user.getPersonalities()),
+                user.getCountry().getName(),
+                user.getCountry().getImage(),
                 user.getJoinAt(),
                 reliability.getLevel(),
                 reliability.getScore(),

--- a/src/main/java/com/gloddy/server/user/domain/vo/Country.java
+++ b/src/main/java/com/gloddy/server/user/domain/vo/Country.java
@@ -1,0 +1,21 @@
+package com.gloddy.server.user.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Country {
+
+    @Column(name = "country_name")
+    private String name;
+
+    @Column(name = "country_image")
+    private String image;
+}

--- a/src/main/java/com/gloddy/server/user/domain/vo/Profile.java
+++ b/src/main/java/com/gloddy/server/user/domain/vo/Profile.java
@@ -40,4 +40,7 @@ public class Profile {
     @Default
     @Column(name = "personality")
     private List<Personality> personalities = new ArrayList<>();
+
+    @Embedded
+    private Country country;
 }

--- a/src/test/java/com/gloddy/server/common/BaseServiceTest.java
+++ b/src/test/java/com/gloddy/server/common/BaseServiceTest.java
@@ -59,7 +59,9 @@ public abstract class BaseServiceTest {
                 "nickName",
                 LocalDate.now(),
                 Gender.MAIL,
-                List.of(Personality.KIND, Personality.ACTIVE, Personality.RESPONSIBLE)
+                List.of(Personality.KIND, Personality.ACTIVE, Personality.RESPONSIBLE),
+                "South Korea",
+                "Korea Image"
         );
 
         return authService.signUp(command).getUserId();


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #133 
### 작업 사항
- [X] 국가 데이터(기획 단에서 선별 해준 80개) 외부 API를 활용하여 프런트 서버에 저장
<img width="300" alt="image" src="https://github.com/gloddy-dev/Gloddy-Server/assets/88091743/ee6f4e2a-4083-4b30-aa86-a61d6ec30b34">

- [X] 회원가입 시 국가 정보 입력 반영
- [X] 유저 프로필 update 시 국가 정보 입력 반영
- [X] 유저 프로필 조회 시 국가 정보 반영

국가 정보에 대한 불변식 검증은 국가 데이터가 너무 많기 때문에 검증에 어려움이 있어 따로 진행하지 않았습니다.(프런트 서버에 있는 미리 저장된 정보를 보내줄거기 때문에 신뢰하도록 합니다.) API 단에서 NotBlack에 대한 validation 검증만 진행하였습니다.

## DDL
```sql
alter table users add country_name varchar(255) after personality;
alter table users add country_image varchar(255) after country_name;
```
