### PR TITLE
[Fix]: 지원서 승인 순간 중복 요청(클라이언트의 더블 클릭)으로 인한 동시성 문제 해결

### DIFF
--- a/src/main/java/com/gloddy/server/apply/domain/service/ApplyStatusUpdateExecutor.java
+++ b/src/main/java/com/gloddy/server/apply/domain/service/ApplyStatusUpdateExecutor.java
@@ -21,7 +21,7 @@ public class ApplyStatusUpdateExecutor {
     public void execute(Long userId, Long applyId, Status status) {
         Apply apply = applyQueryHandler.findById(applyId);
 
-        applyStatusUpdatePolicy.validate(userId, apply.getGroup(), status);
+        applyStatusUpdatePolicy.validate(userId, status, apply);
 
         if (status.isApprove()) {
             apply.approveApply(applyEventProducer);

--- a/src/main/java/com/gloddy/server/apply/domain/service/ApplyStatusUpdatePolicy.java
+++ b/src/main/java/com/gloddy/server/apply/domain/service/ApplyStatusUpdatePolicy.java
@@ -1,6 +1,8 @@
 package com.gloddy.server.apply.domain.service;
 
+import com.gloddy.server.apply.domain.Apply;
 import com.gloddy.server.apply.domain.vo.Status;
+import com.gloddy.server.apply.exception.AlreadyProcessedApplyException;
 import com.gloddy.server.apply.exception.CantAcceptMoreGroupMemberException;
 import com.gloddy.server.apply.exception.UnAuthorizedApplyStatusUpdateException;
 import com.gloddy.server.group.domain.Group;
@@ -11,10 +13,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ApplyStatusUpdatePolicy {
 
-    public void validate(Long userId, Group group, Status status) {
-        validateIsGroupCaptain(userId, group);
-        if (status.isApprove()) {
-            validateCanAcceptMoreGroupMembers(group);
+    public void validate(Long commandUserId, Status commandStatus, Apply apply) {
+        validateIsGroupCaptain(commandUserId, apply.getGroup());
+        validateAlreadyProcessedApply(apply);
+        if (commandStatus.isApprove()) {
+            validateCanAcceptMoreGroupMembers(apply.getGroup());
         }
     }
 
@@ -27,6 +30,12 @@ public class ApplyStatusUpdatePolicy {
     private void validateCanAcceptMoreGroupMembers(Group group) {
         if (!group.canAcceptMoreMembers()) {
             throw new CantAcceptMoreGroupMemberException();
+        }
+    }
+
+    private void validateAlreadyProcessedApply(Apply apply) {
+        if (!apply.getStatus().isWait()) {
+            throw new AlreadyProcessedApplyException();
         }
     }
 

--- a/src/main/java/com/gloddy/server/apply/domain/vo/Status.java
+++ b/src/main/java/com/gloddy/server/apply/domain/vo/Status.java
@@ -13,6 +13,10 @@ public enum Status {
 
     private final String status;
 
+    public boolean isWait() {
+        return this == WAIT;
+    }
+
     public boolean isApprove() {
         return this == APPROVE;
     }

--- a/src/main/java/com/gloddy/server/apply/exception/AlreadyProcessedApplyException.java
+++ b/src/main/java/com/gloddy/server/apply/exception/AlreadyProcessedApplyException.java
@@ -1,0 +1,11 @@
+package com.gloddy.server.apply.exception;
+
+import com.gloddy.server.core.error.handler.errorCode.ErrorCode;
+import com.gloddy.server.core.error.handler.exception.ApplyBusinessException;
+
+public class AlreadyProcessedApplyException extends ApplyBusinessException {
+
+    public AlreadyProcessedApplyException() {
+        super(ErrorCode.AlREADY_PROCESSED_APPLY);
+    }
+}

--- a/src/main/java/com/gloddy/server/core/error/handler/errorCode/ErrorCode.java
+++ b/src/main/java/com/gloddy/server/core/error/handler/errorCode/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     GROUP_NOT_CAPTAIN(403, "권한이 없습니다."),
     APPLY_NOT_FOUND(404, "존재하지 않는 지원서입니다."),
     EXISTS_WAIT_APPLY(400, "대기 상태인 지원서가 존재합니다."),
+    AlREADY_PROCESSED_APPLY(400, "이미 처리된 지원서입니다."),
     NO_TOTAL_GROUP_MEMBER_PRAISE(400, "모든 그룹 참여자에 대해 칭찬 하지 않았습니다"),
 
     SMS_BAD_REQUEST(400, "잘못된 형식의 SMS 요청입니다."),

--- a/src/main/java/com/gloddy/server/core/error/handler/errorCode/ErrorCode.java
+++ b/src/main/java/com/gloddy/server/core/error/handler/errorCode/ErrorCode.java
@@ -53,6 +53,7 @@ public enum ErrorCode {
     EXISTS_WAIT_APPLY(400, "대기 상태인 지원서가 존재합니다."),
     AlREADY_PROCESSED_APPLY(400, "이미 처리된 지원서입니다."),
     NO_TOTAL_GROUP_MEMBER_PRAISE(400, "모든 그룹 참여자에 대해 칭찬 하지 않았습니다"),
+    ALREADY_EXIST_GROUP_MEMBER(400, "이미 해당 유저는 그룹의 멤버입니다."),
 
     SMS_BAD_REQUEST(400, "잘못된 형식의 SMS 요청입니다."),
     SMS_UNAUTHORIZED(401, "유효하지 않은 SMS 요청 헤더값입니다."),

--- a/src/main/java/com/gloddy/server/group/domain/vo/GroupMemberVO.java
+++ b/src/main/java/com/gloddy/server/group/domain/vo/GroupMemberVO.java
@@ -10,7 +10,7 @@ import jakarta.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "group_member_vo")
+@Table(name = "group_member_vo", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "group_id"}))
 public class GroupMemberVO {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gloddy/server/group_member/application/GroupMemberSaveService.java
+++ b/src/main/java/com/gloddy/server/group_member/application/GroupMemberSaveService.java
@@ -1,5 +1,6 @@
 package com.gloddy.server.group_member.application;
 
+import com.gloddy.server.group_member.exception.AlreadyExistGroupMemberException;
 import com.gloddy.server.user.domain.User;
 import com.gloddy.server.group.domain.Group;
 import com.gloddy.server.group.domain.vo.GroupMemberVO;
@@ -8,6 +9,7 @@ import com.gloddy.server.user.domain.handler.UserQueryHandler;
 import com.gloddy.server.group_member.domain.GroupMember;
 import com.gloddy.server.group.domain.handler.GroupQueryHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -20,15 +22,20 @@ public class GroupMemberSaveService {
 
     public GroupMember saveUserGroup(Long userId, Long groupId) {
 
-        Group findGroup = groupQueryHandler.findById(groupId);
-        User findUser = userQueryHandler.findById(userId);
+        try {
 
-        GroupMember groupMember = GroupMember.empty();
-        groupMember.init(findUser, findGroup);
+            Group findGroup = groupQueryHandler.findById(groupId);
+            User findUser = userQueryHandler.findById(userId);
 
-        GroupMemberVO groupMemberVO = groupMember.createUserGroupVO();
-        findGroup.addUserGroupVOs(groupMemberVO);
+            GroupMember groupMember = GroupMember.empty();
+            groupMember.init(findUser, findGroup);
 
-        return groupMemberCommandHandler.save(groupMember);
+            GroupMemberVO groupMemberVO = groupMember.createUserGroupVO();
+            findGroup.addUserGroupVOs(groupMemberVO);
+
+            return groupMemberCommandHandler.save(groupMember);
+        } catch (DataIntegrityViolationException e) {
+            throw new AlreadyExistGroupMemberException();
+        }
     }
 }

--- a/src/main/java/com/gloddy/server/group_member/domain/GroupMember.java
+++ b/src/main/java/com/gloddy/server/group_member/domain/GroupMember.java
@@ -24,7 +24,7 @@ import static com.gloddy.server.group_member.domain.dto.GroupMemberRequest.Estim
 @AllArgsConstructor
 @Entity
 @Getter
-@Table(name = "group_member")
+@Table(name = "group_member", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "group_id"}))
 @EqualsAndHashCode(of = {"id"}, callSuper = false)
 public class GroupMember extends BaseTimeEntity {
 

--- a/src/main/java/com/gloddy/server/group_member/exception/AlreadyExistGroupMemberException.java
+++ b/src/main/java/com/gloddy/server/group_member/exception/AlreadyExistGroupMemberException.java
@@ -1,0 +1,11 @@
+package com.gloddy.server.group_member.exception;
+
+import com.gloddy.server.core.error.handler.errorCode.ErrorCode;
+import com.gloddy.server.core.error.handler.exception.GroupMemberBusinessException;
+
+public class AlreadyExistGroupMemberException extends GroupMemberBusinessException {
+
+    public AlreadyExistGroupMemberException() {
+        super(ErrorCode.ALREADY_EXIST_GROUP_MEMBER);
+    }
+}

--- a/src/test/java/com/gloddy/server/service/apply/ApplyConcurrencyTest.java
+++ b/src/test/java/com/gloddy/server/service/apply/ApplyConcurrencyTest.java
@@ -1,0 +1,74 @@
+package com.gloddy.server.service.apply;
+
+import com.gloddy.server.apply.domain.dto.ApplyRequest;
+import com.gloddy.server.apply.domain.vo.Status;
+import com.gloddy.server.common.myGroup.GroupServiceTest;
+import com.gloddy.server.group.domain.Group;
+import com.gloddy.server.group.domain.dto.GroupRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.TransactionDefinition;
+
+import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class ApplyConcurrencyTest extends GroupServiceTest {
+
+    @Nested
+    class DuplicationRequest {
+        private Long captainId;
+        private Long applyId;
+
+        @BeforeEach
+        void given() {
+
+            transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+            transactionTemplate.execute(status -> {
+                captainId = createUser();
+                Long applierId = createUser();
+
+                GroupRequest.Create groupCreateCommand = createGroupCreateCommand(LocalDate.now().plusDays(1), "11:00");
+                Long groupId = createGroup(captainId, groupCreateCommand);
+
+                applyId = createApply(applierId, groupId, new ApplyRequest.Create(
+                        "introduce",
+                        "reason"));
+                return null;
+            });
+        }
+
+        @Test
+        @DisplayName("방장의 지원서 승인 더블 클릭으로 인한 중복 요청이 발생하였을 때 동시성을 제어한다.")
+        void success() throws InterruptedException {
+
+            int threadCount = 2;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+
+            for (int i = 0; i < threadCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        applyService.updateStatusApply(captainId, applyId, Status.APPROVE);
+                        return null;
+                    } finally {
+                        countDownLatch.countDown();
+                    }
+                });
+            }
+
+            countDownLatch.await();
+
+            Group group = groupJpaRepository.findFirstByOrderByIdDesc();
+            assertThat(group.getMemberCount()).isEqualTo(2);
+
+            clear();
+        }
+    }
+}

--- a/src/test/java/com/gloddy/server/service/apply/ApplyStatusUpdateTest.java
+++ b/src/test/java/com/gloddy/server/service/apply/ApplyStatusUpdateTest.java
@@ -51,6 +51,8 @@ public class ApplyStatusUpdateTest extends GroupServiceTest {
                 .given(applyQueryHandler).findById(applyId);
         willReturn(group)
                 .given(apply).getGroup();
+        willReturn(Status.WAIT)
+                .given(apply).getStatus();
 
         //when_and_then
         Assertions.assertThatThrownBy(() -> applyService.updateStatusApply(captainId, applyId, Status.APPROVE))


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #145 
### 작업 사항
그룹 호스트(방장)의 지원서 승인 시 **더블 클릭으로 인해 아래의 그림과 같이 요청이 순간적으로 2번 이루어져** 중복으로 GroupMember가 생성되는 문제가 발생하였습니다.
![image](https://github.com/gloddy-dev/Gloddy-Server/assets/88091743/ec60f3bc-de3e-4f34-8285-3faf4679abd2)  

위를 해결하기 위한 방법으로 우선 **Application 단에서 해결할 수 있는 지** 부터 검증하였습니다.
일단 Application 단의 코드에는 지원서 update를 하기 전 기존의 검증 로직으로 1. 권한 검증(요청자가 방장인지) 2. 해당 그룹의 인원 초과 검증 총 두개의 검증 로직을 실시합니다. 위의 문제를 해결하기 위해 **지원서가 이미 처리된 지원서 인지(status가 WAIT 인지)에 대한 검증**을 추가한다고 해결할 수 있는지 부터 검증하였습니다. 하지만 아래의 그림과 같이 **DB 단의 동시성 문제**가 발생하였습니다.
<img width="500" alt="image" src="https://github.com/gloddy-dev/Gloddy-Server/assets/88091743/33882325-d028-4eba-a06d-0b1f644652ce">  

따라서 DB 단의 동시성 문제를 해결하기 위해 아래의 해결 방안을 고려하였습니다.
1. **지원서 승인 업데이트 시 ‘비관적 락’을 사용하여 줄을 세우고 이미 처리된 지원서인지 확인합니다.**
2. **지원서 승인 업데이트 시 '낙관적 락'을 사용하여 거의 동시에 들어오는 두 요청 중 마지막 요청을 무효화합니다.**
3. **RDB에 발생할 수 있는 락으로 인한 부하를 줄이기 위해 위의 방법 대신 'Redis 분산락'을 활용합니다.**
4. **그룹 멤버(group_member) 테이블에 userId와 groupId를 복합키로 설정하고 '유니크 제약 조건'을 적용합니다 (선택된 해결 방법).**

저는 4번 방법을 선택하여 해결하였는데, 요청 응답 속도와 개발 리소스를 고려하여 선택하였습니다. 우선 1번 방법과 3번 방법은 **줄세우기** 방법이기 때문에 2번 , 4번 방법에 비해 요청 응답 속도가 느릴 것이라고 판단하여 배제하였습니다. 그리고 2번 방법 보단 4번 방법이 개발 리소스적으로 효율(DDL만 수정하면됨)적이라고 생각하여 4번 방법을 선택하였습니다.

## DDL
```sql
alter table group_member_vo add unique (user_id, group_id);
alter table group_member add unique (user_id, group_id);
```