### PR TITLE
[Feat]: User Internal Preview 조회 API 구현

### DIFF
--- a/src/main/java/com/gloddy/server/auth/application/AuthService.java
+++ b/src/main/java/com/gloddy/server/auth/application/AuthService.java
@@ -67,7 +67,7 @@ public class AuthService {
 
     @Transactional
     public void signOut(Long userId) {
-        User user = userQueryHandler.findByIdAndStatus(userId, Status.ACTIVE);
+        User user = userQueryHandler.findByIdFetch(userId);
         userSignOutPolicy.validate(user);
         user.withDraw();
     }

--- a/src/main/java/com/gloddy/server/group_member/application/GroupMemberService.java
+++ b/src/main/java/com/gloddy/server/group_member/application/GroupMemberService.java
@@ -35,7 +35,7 @@ public class GroupMemberService {
     private final GroupMemberJpaRepository userGroupJpaRepository;
 
     public GroupResponse.GetGroups getExpectedMyGroup(Long userId) {
-        User findUser = userQueryHandler.findByIdAndStatus(userId, Status.ACTIVE);
+        User findUser = userQueryHandler.findByIdFetch(userId);
         List<Group> expectedMyGroups = userGroupJpaRepository.findExpectedGroupsByUser(findUser);
         return expectedMyGroups.stream()
            .map(GroupResponse.GetGroup::from)
@@ -43,7 +43,7 @@ public class GroupMemberService {
     }
 
     public PageResponse<GroupResponse.GetParticipatedGroup> getParticipatedMyGroup(Long userId, int page, int size) {
-        User findUser = userQueryHandler.findByIdAndStatus(userId, Status.ACTIVE);
+        User findUser = userQueryHandler.findByIdFetch(userId);
         return PageResponse.from(
            userGroupJpaRepository.findParticipatedGroupsByUser(findUser, PageRequest.of(page, size))
            .map(GroupResponse.GetParticipatedGroup::from)

--- a/src/main/java/com/gloddy/server/user/api/intenal/UserInternalQueryController.java
+++ b/src/main/java/com/gloddy/server/user/api/intenal/UserInternalQueryController.java
@@ -1,0 +1,26 @@
+package com.gloddy.server.user.api.intenal;
+
+
+import com.gloddy.server.core.response.ApiResponse;
+import com.gloddy.server.user.application.internal.UserInternalQueryService;
+import com.gloddy.server.user.application.internal.dto.UserPreviewResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/internal/payload")
+@RequiredArgsConstructor
+public class UserInternalQueryController {
+
+    private final UserInternalQueryService userInternalQueryService;
+
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<UserPreviewResponse> getUserPreview(@PathVariable("userId") Long userId) {
+        UserPreviewResponse response = userInternalQueryService.getUserPreview(userId);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/com/gloddy/server/user/application/UserUpdateService.java
+++ b/src/main/java/com/gloddy/server/user/application/UserUpdateService.java
@@ -17,7 +17,7 @@ public class UserUpdateService {
 
     @Transactional
     public UserUpdateResponse update(Long userId, Info request) {
-        User user = userQueryHandler.findByIdAndStatus(userId, Status.ACTIVE);
+        User user = userQueryHandler.findByIdFetch(userId);
         user.updateProfile(
                 request.getImageUrl(),
                 request.getName(),

--- a/src/main/java/com/gloddy/server/user/application/facade/UserGetFacade.java
+++ b/src/main/java/com/gloddy/server/user/application/facade/UserGetFacade.java
@@ -21,7 +21,7 @@ public class UserGetFacade {
 
     @Transactional(readOnly = true)
     public UserResponse.FacadeGet getUserFacade(Long userId) {
-        User user = userQueryHandler.findByIdAndStatus(userId, Status.ACTIVE);
+        User user = userQueryHandler.findByIdFetch(userId);
         Long countParticipatedGroup = groupMemberQueryHandler.countParticipatedGroup(userId);
         Long reviewCount = mateQueryHandler.countByUserId(userId);
 

--- a/src/main/java/com/gloddy/server/user/application/internal/UserInternalQueryService.java
+++ b/src/main/java/com/gloddy/server/user/application/internal/UserInternalQueryService.java
@@ -1,0 +1,19 @@
+package com.gloddy.server.user.application.internal;
+
+import com.gloddy.server.user.application.internal.dto.UserPreviewResponse;
+import com.gloddy.server.user.domain.handler.UserQueryHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserInternalQueryService {
+
+    private final UserQueryHandler userQueryHandler;
+
+    public UserPreviewResponse getUserPreview(Long userId) {
+        return userQueryHandler.findUserPreviewById(userId);
+    }
+}

--- a/src/main/java/com/gloddy/server/user/application/internal/dto/UserPreviewResponse.java
+++ b/src/main/java/com/gloddy/server/user/application/internal/dto/UserPreviewResponse.java
@@ -1,0 +1,11 @@
+package com.gloddy.server.user.application.internal.dto;
+
+import com.gloddy.server.user.domain.vo.ReliabilityLevel;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record UserPreviewResponse(Long id, Boolean isCertifiedStudent, String profileImage, String nickName,
+                                  String countryName, String countryImage, ReliabilityLevel reliabilityLevel) {
+    @QueryProjection
+    public UserPreviewResponse {
+    }
+}

--- a/src/main/java/com/gloddy/server/user/domain/User.java
+++ b/src/main/java/com/gloddy/server/user/domain/User.java
@@ -15,6 +15,7 @@ import com.gloddy.server.group.domain.handler.GroupCommandHandler;
 import com.gloddy.server.group.domain.service.GroupFactory;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.Optional;
 @EqualsAndHashCode(of = {"id"}, callSuper = false)
 @Getter
 @Table(name = "users")
+@Where(clause = "status = 'ACTIVE'")
 public class User extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/gloddy/server/user/domain/handler/UserQueryHandler.java
+++ b/src/main/java/com/gloddy/server/user/domain/handler/UserQueryHandler.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface UserQueryHandler {
     User findById(Long id);
 
-    User findByIdAndStatus(Long id, Status status);
+    User findByIdFetch(Long id);
     Optional<User> findByEmail(String email);
 
     boolean existsByNickname(String nickname);

--- a/src/main/java/com/gloddy/server/user/domain/handler/UserQueryHandler.java
+++ b/src/main/java/com/gloddy/server/user/domain/handler/UserQueryHandler.java
@@ -1,8 +1,8 @@
 package com.gloddy.server.user.domain.handler;
 
+import com.gloddy.server.user.application.internal.dto.UserPreviewResponse;
 import com.gloddy.server.user.domain.User;
 import com.gloddy.server.user.domain.vo.Phone;
-import com.gloddy.server.user.domain.vo.kind.Status;
 import com.gloddy.server.user.domain.dto.PraiseResponse;
 
 import java.util.Optional;
@@ -18,4 +18,6 @@ public interface UserQueryHandler {
     Optional<User> findByPhone(Phone phone);
 
     PraiseResponse.GetPraiseForUser findPraiseDtoByUserId(Long userId);
+
+    UserPreviewResponse findUserPreviewById(Long userId);
 }

--- a/src/main/java/com/gloddy/server/user/domain/handler/impl/UserQueryHandlerImpl.java
+++ b/src/main/java/com/gloddy/server/user/domain/handler/impl/UserQueryHandlerImpl.java
@@ -26,8 +26,8 @@ public class UserQueryHandlerImpl implements UserQueryHandler {
     }
 
     @Override
-    public User findByIdAndStatus(Long id, Status status) {
-        return userJpaRepository.findByIdAndStatusFetch(id, status)
+    public User findByIdFetch(Long id) {
+        return userJpaRepository.findByIdFetch(id)
                 .orElseThrow(() -> new UserBusinessException(ErrorCode.USER_NOT_FOUND));
     }
 

--- a/src/main/java/com/gloddy/server/user/domain/handler/impl/UserQueryHandlerImpl.java
+++ b/src/main/java/com/gloddy/server/user/domain/handler/impl/UserQueryHandlerImpl.java
@@ -1,8 +1,8 @@
 package com.gloddy.server.user.domain.handler.impl;
 
+import com.gloddy.server.user.application.internal.dto.UserPreviewResponse;
 import com.gloddy.server.user.domain.User;
 import com.gloddy.server.user.domain.vo.Phone;
-import com.gloddy.server.user.domain.vo.kind.Status;
 import com.gloddy.server.user.domain.dto.PraiseResponse;
 import com.gloddy.server.user.domain.handler.UserQueryHandler;
 import com.gloddy.server.user.infra.repository.UserJpaRepository;
@@ -49,5 +49,11 @@ public class UserQueryHandlerImpl implements UserQueryHandler {
     @Override
     public PraiseResponse.GetPraiseForUser findPraiseDtoByUserId(Long userId) {
         return userJpaRepository.findPraiseByUserId(userId);
+    }
+
+    @Override
+    public UserPreviewResponse findUserPreviewById(Long userId) {
+        return userJpaRepository.findUserPreviewById(userId)
+                .orElseThrow(() -> new UserBusinessException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/gloddy/server/user/infra/repository/custom/UserJpaRepositoryCustom.java
+++ b/src/main/java/com/gloddy/server/user/infra/repository/custom/UserJpaRepositoryCustom.java
@@ -13,7 +13,7 @@ public interface UserJpaRepositoryCustom {
 
     Optional<User> findByEmail(String email);
 
-    Optional<User> findByIdAndStatusFetch(Long id, Status status);
+    Optional<User> findByIdFetch(Long id);
 
     PraiseResponse.GetPraiseForUser findPraiseByUserId(Long userId);
 }

--- a/src/main/java/com/gloddy/server/user/infra/repository/custom/UserJpaRepositoryCustom.java
+++ b/src/main/java/com/gloddy/server/user/infra/repository/custom/UserJpaRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.gloddy.server.user.infra.repository.custom;
 
+import com.gloddy.server.user.application.internal.dto.UserPreviewResponse;
 import com.gloddy.server.user.domain.User;
 import com.gloddy.server.user.domain.vo.Phone;
 import com.gloddy.server.user.domain.vo.kind.Status;
@@ -16,4 +17,6 @@ public interface UserJpaRepositoryCustom {
     Optional<User> findByIdFetch(Long id);
 
     PraiseResponse.GetPraiseForUser findPraiseByUserId(Long userId);
+
+    Optional<UserPreviewResponse> findUserPreviewById(Long id);
 }

--- a/src/main/java/com/gloddy/server/user/infra/repository/impl/UserJpaRepositoryImpl.java
+++ b/src/main/java/com/gloddy/server/user/infra/repository/impl/UserJpaRepositoryImpl.java
@@ -1,8 +1,9 @@
 package com.gloddy.server.user.infra.repository.impl;
 
+import com.gloddy.server.user.application.internal.dto.QUserPreviewResponse;
+import com.gloddy.server.user.application.internal.dto.UserPreviewResponse;
 import com.gloddy.server.user.domain.User;
 import com.gloddy.server.user.domain.vo.Phone;
-import com.gloddy.server.user.domain.vo.kind.Status;
 import com.gloddy.server.user.domain.dto.PraiseResponse;
 import com.gloddy.server.user.domain.dto.QPraiseResponse_GetPraiseForUser;
 import com.gloddy.server.user.infra.repository.custom.UserJpaRepositoryCustom;
@@ -57,6 +58,22 @@ public class UserJpaRepositoryImpl implements UserJpaRepositoryCustom {
                 .where(eqId(userId))
                 .join(user.praise, praise)
                 .fetchOne();
+    }
+
+    @Override
+    public Optional<UserPreviewResponse> findUserPreviewById(Long id) {
+        return Optional.ofNullable(query.select(new QUserPreviewResponse(
+                        user.id,
+                        user.school.isCertifiedStudent,
+                        user.profile.imageUrl,
+                        user.profile.nickname,
+                        user.profile.country.name,
+                        user.profile.country.image,
+                        reliability.level
+                )).from(user)
+                .innerJoin(user.reliability, reliability)
+                .where(eqId(id))
+                .fetchOne());
     }
 
     private BooleanExpression eqPhone(Phone phone) {

--- a/src/main/java/com/gloddy/server/user/infra/repository/impl/UserJpaRepositoryImpl.java
+++ b/src/main/java/com/gloddy/server/user/infra/repository/impl/UserJpaRepositoryImpl.java
@@ -25,21 +25,21 @@ public class UserJpaRepositoryImpl implements UserJpaRepositoryCustom {
     @Override
     public Optional<User> findByPhone(Phone phone) {
         return Optional.ofNullable(query.selectFrom(user)
-                .where(eqPhone(phone), isActive())
+                .where(eqPhone(phone))
                 .fetchOne());
     }
 
     @Override
     public Optional<User> findByEmail(String email) {
         return Optional.ofNullable(query.selectFrom(user)
-                .where(eqEmail(email), isActive())
+                .where(eqEmail(email))
                 .fetchOne());
     }
 
     @Override
-    public Optional<User> findByIdAndStatusFetch(Long id, Status status) {
+    public Optional<User> findByIdFetch(Long id) {
         return Optional.ofNullable(query.selectFrom(user)
-                .where(eqId(id), eqStatus(status))
+                .where(eqId(id))
                 .join(user.praise, praise).fetchJoin()
                 .join(user.reliability, reliability).fetchJoin()
                 .fetchOne());
@@ -65,14 +65,6 @@ public class UserJpaRepositoryImpl implements UserJpaRepositoryCustom {
 
     private BooleanExpression eqEmail(String email) {
         return user.school.email.eq(email);
-    }
-
-    private BooleanExpression isActive() {
-        return user.status.eq(Status.ACTIVE);
-    }
-
-    private BooleanExpression eqStatus(Status status) {
-        return user.status.eq(status);
     }
 
     private BooleanExpression eqId(Long id) {


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #0
## 작업한 이유
- 커뮤니티 서버가 유저 정보를 필요로 하는데 우선 User 정보들을 DynamoDb에 배치로 저장하기 전에 임시로 + **fallback 형태**로 제공하기 위해서 구현하였습니다.
- [ ] 이후 배치를 돌려 dynamodb에 저장해야됨~! (다른 서버에서 조회 성능 및 결합도를 높이기 위함)
## 작업 사항
- Preview Read 모델 생성
```json
{
    "id": 23,
    "isCertifiedStudent": true,
    "profileImage": "https://example.com/profile.jpg",
    "nickName": "nickname",
    "countryName": "Korea",
    "countryImage": "https://example.com/country.jpg",
    "reliabilityLevel": "HOOD"
}
```
- Internal User Preview API 로직 구현
  - 쿼리작성 및 코드 구현