### PR TITLE
[Feat]: User Internal 일괄 조회 API 구현

### DIFF
--- a/src/main/java/com/gloddy/server/user/api/intenal/UserInternalQueryController.java
+++ b/src/main/java/com/gloddy/server/user/api/intenal/UserInternalQueryController.java
@@ -4,12 +4,12 @@ package com.gloddy.server.user.api.intenal;
 import com.gloddy.server.core.response.ApiResponse;
 import com.gloddy.server.user.application.internal.UserInternalQueryService;
 import com.gloddy.server.user.application.internal.dto.UserPreviewResponse;
+import com.gloddy.server.user.application.internal.dto.UserPreviewsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collection;
 
 @RestController
 @RequestMapping("/api/internal/payload")
@@ -21,6 +21,14 @@ public class UserInternalQueryController {
     @GetMapping("/users/{userId}")
     public ResponseEntity<UserPreviewResponse> getUserPreview(@PathVariable("userId") Long userId) {
         UserPreviewResponse response = userInternalQueryService.getUserPreview(userId);
+        return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/users")
+    public ResponseEntity<UserPreviewsResponse> getUserPreviews(
+            @RequestParam("ids") Collection<Long> ids
+    ) {
+        UserPreviewsResponse response = userInternalQueryService.getUserPreviews(ids);
         return ApiResponse.ok(response);
     }
 }

--- a/src/main/java/com/gloddy/server/user/application/internal/UserInternalQueryService.java
+++ b/src/main/java/com/gloddy/server/user/application/internal/UserInternalQueryService.java
@@ -1,10 +1,13 @@
 package com.gloddy.server.user.application.internal;
 
 import com.gloddy.server.user.application.internal.dto.UserPreviewResponse;
+import com.gloddy.server.user.application.internal.dto.UserPreviewsResponse;
 import com.gloddy.server.user.domain.handler.UserQueryHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
 
 @Service
 @RequiredArgsConstructor
@@ -15,5 +18,9 @@ public class UserInternalQueryService {
 
     public UserPreviewResponse getUserPreview(Long userId) {
         return userQueryHandler.findUserPreviewById(userId);
+    }
+
+    public UserPreviewsResponse getUserPreviews(Collection<Long> ids) {
+        return userQueryHandler.findUserPreviewsByInId(ids);
     }
 }

--- a/src/main/java/com/gloddy/server/user/application/internal/dto/UserPreviewsResponse.java
+++ b/src/main/java/com/gloddy/server/user/application/internal/dto/UserPreviewsResponse.java
@@ -1,0 +1,8 @@
+package com.gloddy.server.user.application.internal.dto;
+
+import java.util.List;
+
+public record UserPreviewsResponse(
+        List<UserPreviewResponse> users
+) {
+}

--- a/src/main/java/com/gloddy/server/user/domain/handler/UserQueryHandler.java
+++ b/src/main/java/com/gloddy/server/user/domain/handler/UserQueryHandler.java
@@ -1,10 +1,12 @@
 package com.gloddy.server.user.domain.handler;
 
 import com.gloddy.server.user.application.internal.dto.UserPreviewResponse;
+import com.gloddy.server.user.application.internal.dto.UserPreviewsResponse;
 import com.gloddy.server.user.domain.User;
 import com.gloddy.server.user.domain.vo.Phone;
 import com.gloddy.server.user.domain.dto.PraiseResponse;
 
+import java.util.Collection;
 import java.util.Optional;
 
 public interface UserQueryHandler {
@@ -20,4 +22,6 @@ public interface UserQueryHandler {
     PraiseResponse.GetPraiseForUser findPraiseDtoByUserId(Long userId);
 
     UserPreviewResponse findUserPreviewById(Long userId);
+
+    UserPreviewsResponse findUserPreviewsByInId(Collection<Long> userIds);
 }

--- a/src/main/java/com/gloddy/server/user/domain/handler/impl/UserQueryHandlerImpl.java
+++ b/src/main/java/com/gloddy/server/user/domain/handler/impl/UserQueryHandlerImpl.java
@@ -1,6 +1,7 @@
 package com.gloddy.server.user.domain.handler.impl;
 
 import com.gloddy.server.user.application.internal.dto.UserPreviewResponse;
+import com.gloddy.server.user.application.internal.dto.UserPreviewsResponse;
 import com.gloddy.server.user.domain.User;
 import com.gloddy.server.user.domain.vo.Phone;
 import com.gloddy.server.user.domain.dto.PraiseResponse;
@@ -11,6 +12,8 @@ import com.gloddy.server.core.error.handler.exception.UserBusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -55,5 +58,11 @@ public class UserQueryHandlerImpl implements UserQueryHandler {
     public UserPreviewResponse findUserPreviewById(Long userId) {
         return userJpaRepository.findUserPreviewById(userId)
                 .orElseThrow(() -> new UserBusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Override
+    public UserPreviewsResponse findUserPreviewsByInId(Collection<Long> userIds) {
+        List<UserPreviewResponse> userPreviews = userJpaRepository.findUserPreviewsByInId(userIds);
+        return new UserPreviewsResponse(userPreviews);
     }
 }

--- a/src/main/java/com/gloddy/server/user/infra/repository/custom/UserJpaRepositoryCustom.java
+++ b/src/main/java/com/gloddy/server/user/infra/repository/custom/UserJpaRepositoryCustom.java
@@ -6,7 +6,10 @@ import com.gloddy.server.user.domain.vo.Phone;
 import com.gloddy.server.user.domain.vo.kind.Status;
 import com.gloddy.server.user.domain.dto.PraiseResponse;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface UserJpaRepositoryCustom {
 
@@ -19,4 +22,6 @@ public interface UserJpaRepositoryCustom {
     PraiseResponse.GetPraiseForUser findPraiseByUserId(Long userId);
 
     Optional<UserPreviewResponse> findUserPreviewById(Long id);
+
+    List<UserPreviewResponse> findUserPreviewsByInId(Collection<Long> ids);
 }

--- a/src/main/java/com/gloddy/server/user/infra/repository/impl/UserJpaRepositoryImpl.java
+++ b/src/main/java/com/gloddy/server/user/infra/repository/impl/UserJpaRepositoryImpl.java
@@ -12,7 +12,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.*;
 
 import static com.gloddy.server.user.domain.QUser.*;
 import static com.gloddy.server.user.domain.QPraise.*;
@@ -76,6 +76,22 @@ public class UserJpaRepositoryImpl implements UserJpaRepositoryCustom {
                 .fetchOne());
     }
 
+    @Override
+    public List<UserPreviewResponse> findUserPreviewsByInId(Collection<Long> ids) {
+        return query.select(new QUserPreviewResponse(
+                        user.id,
+                        user.school.isCertifiedStudent,
+                        user.profile.imageUrl,
+                        user.profile.nickname,
+                        user.profile.country.name,
+                        user.profile.country.image,
+                        reliability.level
+                )).from(user)
+                .innerJoin(user.reliability, reliability)
+                .where(inId(ids))
+                .fetch();
+    }
+
     private BooleanExpression eqPhone(Phone phone) {
         return user.phone.eq(phone);
     }
@@ -86,5 +102,9 @@ public class UserJpaRepositoryImpl implements UserJpaRepositoryCustom {
 
     private BooleanExpression eqId(Long id) {
         return user.id.eq(id);
+    }
+
+    private BooleanExpression inId(Collection<Long> ids) {
+        return user.id.in(ids);
     }
 }


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #0
## 작업한 이유
커뮤니티 서버에서 유저 정보를 일괄적으로 조회하기 위함. 이후에 유저정보를 분산환경(dynamodb)에 배치작업 + 커뮤니티 중첩데이터로 저장할 예정임
### 작업 사항
- User Internal 일괄 조회 API 구현
  - 쿼리 및 로직 작성