### PR TITLE
[Fix]: User 프로필 수정 시 Request Body Unknown 필드 받을 수 있도록 수정

### DIFF
--- a/src/main/java/com/gloddy/server/user/domain/dto/UserUpdateRequest.java
+++ b/src/main/java/com/gloddy/server/user/domain/dto/UserUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.gloddy.server.user.domain.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.gloddy.server.user.domain.vo.kind.Gender;
 import com.gloddy.server.user.domain.vo.kind.Personality;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,6 +17,7 @@ public class UserUpdateRequest {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
     @Schema(name = "UserUpdateRequest")
     public static class Info {
         private String imageUrl;


### PR DESCRIPTION
### Issue number
<!-- # 뒤에는 이슈 번호 걸어주세요 -->
- resolved #160 
### 작업 사항
현재 프런트에서 프로필 수정 시 해당 유저에 대한 모든 필드를 바디에 넣어서 보내고 있는데(프런트가 귀찮았는 듯? ㅋㅋ), 수정 시 필요한 필드는 정해져있습니다. 따라서 Spring에서 아래와 같은 에러를 내뱉는데, Unknown필드도 받을 수 있도록 하여 아래의 예외를 내뱉지 않도록 수정하였습니다.
`org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Unrecognized field `
